### PR TITLE
feat: add list command with filtering and blocker resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # bmad — BMAD Story Runner CLI
 
-A Go CLI tool that replaces ad-hoc Python/bash scripts in the [BMAD Story Runner skill](https://github.com/sosalejandro/bmad-story-runner-cli). It manages `bmad-progress.json`, story status transitions, QA gate checks, and reconciliation — all from a single binary.
+**The CLI companion for AI-assisted software development with the BMAD Method.** Built for Claude Code, Cursor, Windsurf, Copilot Workspace, and any AI coding agent that manages multi-story implementation workflows.
+
+`bmad` replaces ad-hoc Python/bash scripts with a single Go binary that tracks story progress, manages QA gates, resolves blockers, and coordinates parallel agent sessions — so your AI assistant spends tokens on code, not on reinventing progress management.
+
+**Key features for AI-assisted developers:**
+- **Progress tracking** — `bmad-progress.json` as the single source of truth across agent sessions
+- **Blocker resolution** — prefix-aware dependency matching (`2.1` resolves blockers on `2.1.payment-api`)
+- **Parallel agent coordination** — assign story groups, claim sessions, reconcile QA results
+- **Story filtering** — list and query stories by status, group, and blocker state
+- **Audit logging** — every CLI invocation is logged with performance metrics for workflow optimization
+- **Zero-config discovery** — `bmad init` scans your docs folder and builds the progress file automatically
 
 ## Installation
 
@@ -176,6 +186,60 @@ STORY        ACs    TASKS        TITLE
 2.8          6      33/33        Checkout Session Verification
 3.2          7      28/31        Payment Webhook Handler
 ```
+
+---
+
+### `bmad list <progress-json>`
+
+List stories with flexible filtering by group, status, and blocker resolution. Designed for AI agents that need to query progress state without parsing raw JSON.
+
+```bash
+# List all stories
+bmad list ./bmad-progress.json
+
+# Filter by parallel group
+bmad list ./bmad-progress.json --group 3 --filter-group
+
+# Filter by status
+bmad list ./bmad-progress.json --status pending
+
+# Show only unblocked stories (all blockers resolved)
+bmad list ./bmad-progress.json --unblocked-only
+
+# Show blocker IDs with resolution status (✓/✗)
+bmad list ./bmad-progress.json --show-blockers
+
+# Combine filters
+bmad list ./bmad-progress.json --group 2 --filter-group --status pending --unblocked-only --show-blockers
+```
+
+Output:
+```
+STATUS      | STORY ID                    | TITLE
+------------|-----------------------------|---------
+pending     | 2.1.payment-api             | Payment API
+pending     | 2.2.invoice-gen             | Invoice Generator
+
+2 stories listed.
+```
+
+With `--show-blockers`:
+```
+STATUS      | STORY ID                    | BLOCKERS
+------------|-----------------------------|---------
+pending     | 1.2.user-profile            | 1.1 (✓)
+blocked     | 2.2.invoice-gen             | 2.1 (✗)
+
+2 stories listed.
+```
+
+Blocker resolution uses prefix-aware matching — blocker `1.1` resolves against story `1.1.auth-service` and shows `✓` if that story is complete.
+
+Flags:
+- `--group <n>` + `--filter-group` — restrict to a specific parallel group
+- `--status <status>` — filter by status (`pending`, `in-progress`, `qa-review`, `complete`, `blocked`)
+- `--show-blockers` — show blocker IDs with resolution markers instead of title
+- `--unblocked-only` — only show stories whose blockers are all resolved (or have no blockers)
 
 ---
 

--- a/application/list_stories.go
+++ b/application/list_stories.go
@@ -1,0 +1,82 @@
+package application
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/ports"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain"
+)
+
+type ListStoriesUseCase struct {
+	store ports.ProgressStore
+	log   *zap.Logger
+}
+
+func NewListStoriesUseCase(store ports.ProgressStore, log *zap.Logger) *ListStoriesUseCase {
+	return &ListStoriesUseCase{store: store, log: log}
+}
+
+// ListFilter controls which stories are returned.
+type ListFilter struct {
+	Group         *int
+	Status        *domain.Status
+	UnblockedOnly bool
+}
+
+// BlockerInfo describes a blocker and whether it is resolved.
+type BlockerInfo struct {
+	ID       string
+	Resolved bool
+}
+
+// ListRow is one row in the list output.
+type ListRow struct {
+	Story    *domain.Story
+	Blockers []BlockerInfo
+}
+
+func (uc *ListStoriesUseCase) Execute(progressPath string, filter ListFilter) ([]ListRow, error) {
+	progress, err := uc.store.Load(progressPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading progress file %q: %w", progressPath, err)
+	}
+
+	var rows []ListRow
+
+	for _, s := range progress.Stories {
+		if filter.Group != nil && (s.ParallelGroup == nil || *s.ParallelGroup != *filter.Group) {
+			continue
+		}
+		if filter.Status != nil && s.Status != *filter.Status {
+			continue
+		}
+
+		var blockers []BlockerInfo
+		allResolved := true
+		for _, b := range s.Blockers {
+			resolved := false
+			if found := progress.FindByID(b); found != nil && found.Status == domain.StatusComplete {
+				resolved = true
+			}
+			if !resolved {
+				allResolved = false
+			}
+			blockers = append(blockers, BlockerInfo{ID: b, Resolved: resolved})
+		}
+
+		if filter.UnblockedOnly && !allResolved {
+			continue
+		}
+
+		rows = append(rows, ListRow{Story: s, Blockers: blockers})
+	}
+
+	uc.log.Debug("list stories",
+		zap.Int("matched", len(rows)),
+		zap.Int("total", len(progress.Stories)),
+	)
+
+	return rows, nil
+}

--- a/application/list_stories_test.go
+++ b/application/list_stories_test.go
@@ -1,0 +1,156 @@
+package application_test
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain"
+)
+
+type mockProgressStore struct {
+	progress *domain.ProgressFile
+}
+
+func (m *mockProgressStore) Load(_ string) (*domain.ProgressFile, error) {
+	return m.progress, nil
+}
+
+func (m *mockProgressStore) Save(_ string, _ *domain.ProgressFile) error {
+	return nil
+}
+
+func intPtr(v int) *int { return &v }
+
+func makeProgress() *domain.ProgressFile {
+	return &domain.ProgressFile{
+		Version:    1,
+		DocsFolder: "/tmp/test",
+		Stories: []*domain.Story{
+			{ID: "1.1.auth-service", Status: domain.StatusComplete, ParallelGroup: intPtr(1)},
+			{ID: "1.2.user-profile", Status: domain.StatusPending, ParallelGroup: intPtr(1), Blockers: []string{"1.1"}},
+			{ID: "2.1.payment-api", Status: domain.StatusPending, ParallelGroup: intPtr(2)},
+			{ID: "2.2.invoice-gen", Status: domain.StatusBlocked, ParallelGroup: intPtr(2), Blockers: []string{"2.1"}},
+			{ID: "3.1.analytics", Status: domain.StatusInProgress, ParallelGroup: intPtr(3)},
+		},
+	}
+}
+
+func TestListStories_NoFilter(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	rows, err := uc.Execute("test.json", application.ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 5 {
+		t.Errorf("expected 5 rows, got %d", len(rows))
+	}
+}
+
+func TestListStories_FilterByGroup(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	group := 2
+	rows, err := uc.Execute("test.json", application.ListFilter{Group: &group})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows for group 2, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Story.ParallelGroup == nil || *r.Story.ParallelGroup != 2 {
+			t.Errorf("story %s not in group 2", r.Story.ID)
+		}
+	}
+}
+
+func TestListStories_FilterByStatus(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	st := domain.StatusPending
+	rows, err := uc.Execute("test.json", application.ListFilter{Status: &st})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 pending rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Story.Status != domain.StatusPending {
+			t.Errorf("story %s has status %s, expected pending", r.Story.ID, r.Story.Status)
+		}
+	}
+}
+
+func TestListStories_FilterByGroupAndStatus(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	group := 1
+	st := domain.StatusPending
+	rows, err := uc.Execute("test.json", application.ListFilter{Group: &group, Status: &st})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 row (group 1, pending), got %d", len(rows))
+	}
+	if len(rows) > 0 && rows[0].Story.ID != "1.2.user-profile" {
+		t.Errorf("expected 1.2.user-profile, got %s", rows[0].Story.ID)
+	}
+}
+
+func TestListStories_UnblockedOnly(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	rows, err := uc.Execute("test.json", application.ListFilter{UnblockedOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1.1 (complete, no blockers) ✓
+	// 1.2 (pending, blocker 1.1 is complete) ✓
+	// 2.1 (pending, no blockers) ✓
+	// 2.2 (blocked, blocker 2.1 is NOT complete) ✗
+	// 3.1 (in-progress, no blockers) ✓
+	if len(rows) != 4 {
+		t.Errorf("expected 4 unblocked rows, got %d", len(rows))
+		for _, r := range rows {
+			t.Logf("  %s (status=%s, blockers=%v)", r.Story.ID, r.Story.Status, r.Story.Blockers)
+		}
+	}
+}
+
+func TestListStories_ShowBlockersResolution(t *testing.T) {
+	store := &mockProgressStore{progress: makeProgress()}
+	uc := application.NewListStoriesUseCase(store, zap.NewNop())
+
+	group := 1
+	rows, err := uc.Execute("test.json", application.ListFilter{Group: &group})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Story 1.2 has blocker "1.1" which should be resolved (1.1 is complete)
+	found := false
+	for _, r := range rows {
+		if r.Story.ID == "1.2.user-profile" {
+			found = true
+			if len(r.Blockers) != 1 {
+				t.Errorf("expected 1 blocker, got %d", len(r.Blockers))
+			}
+			if len(r.Blockers) > 0 && !r.Blockers[0].Resolved {
+				t.Error("blocker 1.1 should be resolved (story is complete)")
+			}
+		}
+	}
+	if !found {
+		t.Error("story 1.2.user-profile not found in results")
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure"
+)
+
+func newListCmd() *cobra.Command {
+	var (
+		group         int
+		filterGroup   bool
+		status        string
+		showBlockers  bool
+		unblockedOnly bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list <progress-json>",
+		Short: "List stories with filtering by group, status, and blocker resolution",
+		Long: `List stories from the progress file with flexible filtering.
+
+Examples:
+  bmad list progress.json --group 3 --filter-group
+  bmad list progress.json --status pending --show-blockers
+  bmad list progress.json --group 3 --filter-group --unblocked-only`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := infrastructure.NewJSONProgressStore(log)
+			uc := application.NewListStoriesUseCase(store, log)
+
+			filter := application.ListFilter{
+				UnblockedOnly: unblockedOnly,
+			}
+			if filterGroup {
+				filter.Group = &group
+			}
+			if status != "" {
+				st, err := domain.ParseStatus(status)
+				if err != nil {
+					return err
+				}
+				filter.Status = &st
+			}
+
+			rows, err := uc.Execute(args[0], filter)
+			if err != nil {
+				return err
+			}
+
+			if len(rows) == 0 {
+				fmt.Println("No stories match the given filters.")
+				return nil
+			}
+
+			printListTable(rows, showBlockers)
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&group, "group", 0, "Filter to a specific parallel group number")
+	cmd.Flags().BoolVar(&filterGroup, "filter-group", false, "Enable group filtering (use with --group)")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status (pending, in-progress, qa-review, complete, blocked)")
+	cmd.Flags().BoolVar(&showBlockers, "show-blockers", false, "Show blocker IDs with resolution status")
+	cmd.Flags().BoolVar(&unblockedOnly, "unblocked-only", false, "Only show stories whose blockers are all resolved")
+
+	return cmd
+}
+
+func printListTable(rows []application.ListRow, showBlockers bool) {
+	// Calculate column widths.
+	maxStatus := len("STATUS")
+	maxID := len("STORY ID")
+	for _, r := range rows {
+		if l := len(string(r.Story.Status)); l > maxStatus {
+			maxStatus = l
+		}
+		if l := len(r.Story.ID); l > maxID {
+			maxID = l
+		}
+	}
+
+	if showBlockers {
+		fmt.Printf("%-*s | %-*s | BLOCKERS\n", maxStatus, "STATUS", maxID, "STORY ID")
+		fmt.Printf("%s-|-%s-|-%s\n", repeat("-", maxStatus), repeat("-", maxID), repeat("-", 30))
+	} else {
+		fmt.Printf("%-*s | %-*s | TITLE\n", maxStatus, "STATUS", maxID, "STORY ID")
+		fmt.Printf("%s-|-%s-|-%s\n", repeat("-", maxStatus), repeat("-", maxID), repeat("-", 30))
+	}
+
+	for _, r := range rows {
+		if showBlockers {
+			blockerStr := formatBlockers(r.Blockers)
+			fmt.Printf("%-*s | %-*s | %s\n", maxStatus, string(r.Story.Status), maxID, r.Story.ID, blockerStr)
+		} else {
+			fmt.Printf("%-*s | %-*s | %s\n", maxStatus, string(r.Story.Status), maxID, r.Story.ID, r.Story.Title)
+		}
+	}
+
+	fmt.Printf("\n%d stories listed.\n", len(rows))
+}
+
+func formatBlockers(blockers []application.BlockerInfo) string {
+	if len(blockers) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(blockers))
+	for _, b := range blockers {
+		marker := "✗"
+		if b.Resolved {
+			marker = "✓"
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", b.ID, marker))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ so Claude does not need to write inline Python or bash scripts.`,
 		newReconcileCmd(),
 		newWriteGateCmd(),
 		newExecCmd(),
+		newListCmd(),
 		newLogCmd(),
 	)
 


### PR DESCRIPTION
## Summary

- Adds `bmad list <progress-json>` command for querying stories with flexible filters
- Supports `--group`, `--filter-group`, `--status`, `--show-blockers`, and `--unblocked-only` flags
- Uses prefix-aware blocker resolution via `FindByID()` so short blocker refs like `"1.1"` correctly resolve against full story IDs like `"1.1.auth-service"`
- Includes 6 unit tests covering all filter combinations and blocker resolution
- Updates README with SEO-enhanced description targeting AI-assisted developers (Claude Code, Cursor, Windsurf, Copilot Workspace)

## Motivation

Identified from audit log analysis (issue #2): 8 `bmad exec` workarounds were all performing group/status/blocker queries via inline Python scripts. This native command eliminates those workarounds and provides a structured, filterable view of story progress.

## New files

| File | Purpose |
|------|---------|
| `application/list_stories.go` | `ListStoriesUseCase` — filters stories by group, status, blocker state |
| `application/list_stories_test.go` | 6 test cases with mock progress store |
| `cmd/list.go` | Cobra command with table output and blocker formatting |

## Test plan

- [x] `TestListStories_NoFilter` — returns all 5 stories
- [x] `TestListStories_FilterByGroup` — filters to group 2 only
- [x] `TestListStories_FilterByStatus` — filters to pending only
- [x] `TestListStories_FilterByGroupAndStatus` — combined filter
- [x] `TestListStories_UnblockedOnly` — excludes stories with unresolved blockers
- [x] `TestListStories_ShowBlockersResolution` — verifies prefix-aware blocker resolution
- [x] Full test suite passes: `go test ./...`
- [x] Binary builds: `go build ./cmd/bmad/`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)