### PR TITLE
feat(prompts): direct agents to atlas CLI + bump atlas dep to v0.1.0

### DIFF
--- a/infrastructure/prompts/templates/stage_hydrate.tmpl
+++ b/infrastructure/prompts/templates/stage_hydrate.tmpl
@@ -70,6 +70,32 @@ for a sprint-wide standing corpus.
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
 
+## Codebase discovery — prefer atlas CLI over grep
+
+The `atlas` binary is on PATH (pinned at v0.1.0 in nutrition's
+`taskfiles/atlas.yml`). For ad-hoc codebase queries during hydration,
+prefer the indexed atlas verbs over `grep` / `find`:
+
+```
+atlas codebase find <symbol>       — file:line for a qualified name
+atlas codebase bc <bc-name>        — annotations + symbols within a BC
+atlas codebase agg <aggregate-id>  — aggregate decl + canonical service
+atlas codebase emit <event-name>   — emit + outbox-publish sites
+atlas codebase pattern <name>      — symbols matching a parser recognizer
+                                     (outbox-append / event-recorder-embed /
+                                      canonical-service)
+atlas trace <feature-or-symbol>    — graph walk
+atlas trace saga:<id>              — ordered saga steps
+atlas diagnose "<symptom>"         — symptom → symbol matcher
+```
+
+Each verb supports `--json` for programmatic output. `atlas --help` for
+full verb listing. The atlas state DB is at `.atlas/atlas.db`
+(gitignored). Note: `atlas trace` takes a Go SymbolID (e.g.
+`PatientService.AssignPatient`), not a feature-id (`plans-patient.export-pdf`)
+— use `atlas codebase find` to resolve a feature ID's primary symbol
+first.
+
 ## What to do
 
 Follow your agent definition's hydration protocol. Write the hydrated

--- a/infrastructure/prompts/templates/stage_implement.tmpl
+++ b/infrastructure/prompts/templates/stage_implement.tmpl
@@ -45,6 +45,32 @@ already consumed this file; if you need quick reminders of the spec's
 {{.EpicContext}}
 {{- end}}
 
+## Codebase discovery — prefer atlas CLI over grep
+
+The `atlas` binary is on PATH (pinned at v0.1.0 in nutrition's
+`taskfiles/atlas.yml`). For ad-hoc codebase queries during
+implementation, prefer the indexed atlas verbs over `grep` / `find`:
+
+```
+atlas codebase find <symbol>       — file:line for a qualified name
+atlas codebase bc <bc-name>        — annotations + symbols within a BC
+atlas codebase agg <aggregate-id>  — aggregate decl + canonical service
+atlas codebase emit <event-name>   — emit + outbox-publish sites
+atlas codebase pattern <name>      — symbols matching a parser recognizer
+                                     (outbox-append / event-recorder-embed /
+                                      canonical-service)
+atlas trace <feature-or-symbol>    — graph walk
+atlas trace saga:<id>              — ordered saga steps
+atlas diagnose "<symptom>"         — symptom → symbol matcher
+```
+
+Each verb supports `--json` for programmatic output. `atlas --help` for
+full verb listing. The atlas state DB is at `.atlas/atlas.db`
+(gitignored). Note: `atlas trace` takes a Go SymbolID (e.g.
+`PatientService.AssignPatient`), not a feature-id (`plans-patient.export-pdf`)
+— use `atlas codebase find` to resolve a feature ID's primary symbol
+first.
+
 ## What to do
 
 1. Read the hydrated spec at `{{.HydratedFile}}`.


### PR DESCRIPTION
## Summary

- Add a "Codebase discovery — prefer atlas CLI over grep" block to
  `stage_hydrate.tmpl` and `stage_implement.tmpl`. Lists the atlas v0.1.0
  codebase verbs (`find` / `bc` / `agg` / `emit` / `pattern`), the trace
  verbs (`trace`, `trace saga:`), and `diagnose`. Agents now know to reach
  for atlas indexed lookups before `grep` / `find`.
- Flags the SymbolID-vs-feature-id ergonomic — `atlas trace
  PatientService.AssignPatient` works; `atlas trace
  plans-patient.export-pdf` returns `trace: no symbol matches`. Without
  this hint, agents discover it the slow way.

## Scope note on the "go.mod bump"

The original task brief mentioned bumping `bmad-cli`'s atlas dependency
in `go.mod` from a commit pseudo-version to `v0.1.0`. After checking,
bmad-cli has **no atlas dependency in `go.mod`** at all and no import of
`sosalejandro/atlas` anywhere in the source tree — so there's nothing to
bump. The `atlas` binary the templates reference is the standalone CLI
installed via `go install github.com/sosalejandro/atlas/cmd/atlas@v0.1.0`
on the worker host (as pinned by nutrition's `taskfiles/atlas.yml`),
not a library link.

Closes the first half of #12 (the "agents should use atlas CLI" half).
The library-dep half doesn't apply because there's no library dep yet.

## Verified

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all suites pass

## Test plan

- [ ] Render `stage_hydrate.tmpl` with a representative slot bundle and
      eyeball the rendered atlas section
- [ ] Render `stage_implement.tmpl` and eyeball the rendered atlas
      section
- [ ] Verify the "atlas trace takes a SymbolID, not a feature-id" hint
      is preserved in both renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)