### PR TITLE
feat: 4 fixes from Epic 1 retrospective (#14 #15 #16 #17)

### DIFF
--- a/application/sprint/parser.go
+++ b/application/sprint/parser.go
@@ -35,6 +35,12 @@ type ParsedStory struct {
 	Frontmatter StoryFrontmatter
 	SourceFile  string
 	StoryTitle  string // markdown title (### Story X.Y: <title>); fallback for Frontmatter.Title
+	// HasFrontmatter is true iff the parser saw a non-empty YAML block between
+	// `---` delimiters for this story. Stories that fall through with just the
+	// header-derived StoryID + Title (no yaml at all, or an empty `---\n---`)
+	// are flagged false — the planner's coverage-warning surfaces these so an
+	// operator can backfill dependencies before sprinting through them.
+	HasFrontmatter bool
 }
 
 var (
@@ -146,7 +152,34 @@ func commit(s *ParsedStory, buf *strings.Builder) error {
 		fm.Title = s.StoryTitle
 	}
 	s.Frontmatter = fm
+	s.HasFrontmatter = true
 	return nil
+}
+
+// EpicIDFromStory returns the epic-id prefix for a story id, e.g. "1.1" → "1",
+// "10.4" → "10", "4.1.payment-method-mgmt" → "4". Returns the input unchanged
+// when no dot is present (the caller can decide what that means).
+func EpicIDFromStory(storyID string) string {
+	if i := strings.IndexByte(storyID, '.'); i >= 0 {
+		return storyID[:i]
+	}
+	return storyID
+}
+
+// StoryMatchesEpic returns true when storyID is in the scope of epicID:
+//
+//	"1"    matches "1.1", "1.2"   (prefix + dot)
+//	"1"    matches "1"            (exact equality)
+//	"1"    does NOT match "10.1"  (avoids the off-by-one prefix bug)
+//	""     matches everything (an empty scope is a no-op filter)
+func StoryMatchesEpic(storyID, epicID string) bool {
+	if epicID == "" {
+		return true
+	}
+	if storyID == epicID {
+		return true
+	}
+	return strings.HasPrefix(storyID, epicID+".")
 }
 
 // ToStory converts a parsed-story to a domain.Story ready for Stories.Insert.

--- a/application/sprint/parser_test.go
+++ b/application/sprint/parser_test.go
@@ -100,4 +100,111 @@ Body without frontmatter — should still parse to a stub story.
 	if stories[0].Frontmatter.StoryID != "9.9" {
 		t.Errorf("StoryID = %q, want 9.9 from header", stories[0].Frontmatter.StoryID)
 	}
+	if stories[0].HasFrontmatter {
+		t.Errorf("HasFrontmatter = true; want false for a header-only story (issue #14)")
+	}
+}
+
+// HasFrontmatter must be true when YAML was actually parsed — this lets the
+// coverage warning distinguish "no frontmatter" from "frontmatter present but
+// depends_on empty (top-level on purpose)". Issue #14.
+func TestParseEpicsFile_HasFrontmatterFlagSetOnYAML(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `### Story 1.1: With FM
+
+---
+story_id: "1.1"
+depends_on: []
+---
+
+### Story 9.9: Without FM
+`)
+	stories, _ := sprint.ParseEpicsFile(path)
+	if len(stories) != 2 {
+		t.Fatalf("len = %d, want 2", len(stories))
+	}
+	if !stories[0].HasFrontmatter {
+		t.Errorf("story 1.1: HasFrontmatter = false; want true (YAML block present)")
+	}
+	if stories[1].HasFrontmatter {
+		t.Errorf("story 9.9: HasFrontmatter = true; want false (no YAML)")
+	}
+}
+
+func TestEpicIDFromStory(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ in, want string }{
+		{"1.1", "1"},
+		{"10.4", "10"},
+		{"1", "1"},                                  // no dot → return input
+		{"4.1.payment-method-mgmt", "4"},            // multi-dot
+		{"plans-patient.export-pdf", "plans-patient"}, // slug id
+	} {
+		if got := sprint.EpicIDFromStory(tc.in); got != tc.want {
+			t.Errorf("EpicIDFromStory(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStoryMatchesEpic_PrefixDotBoundary(t *testing.T) {
+	t.Parallel()
+	// The "1" vs "10" off-by-one prefix bug: a naive HasPrefix("10.1", "1")
+	// would match incorrectly. We require either equality or "<epic>.".
+	cases := []struct {
+		story, epic string
+		want        bool
+	}{
+		{"1.1", "1", true},
+		{"1.2", "1", true},
+		{"1", "1", true},
+		{"10.1", "1", false}, // critical: must NOT match
+		{"10.1", "10", true},
+		{"2.1", "1", false},
+		{"4.1.payment-method-mgmt", "4", true},
+		{"x.1", "", true}, // empty scope = no filter
+	}
+	for _, tc := range cases {
+		if got := sprint.StoryMatchesEpic(tc.story, tc.epic); got != tc.want {
+			t.Errorf("StoryMatchesEpic(%q, %q) = %v, want %v", tc.story, tc.epic, got, tc.want)
+		}
+	}
+}
+
+func TestAnalyseCoverage_FlagsUnannotated(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "1.1"}, HasFrontmatter: true},
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "1.2"}, HasFrontmatter: true},
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "10.1"}, HasFrontmatter: false},
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "10.2"}, HasFrontmatter: false},
+	}
+	r := sprint.AnalyseCoverage(parsed)
+	if r.TotalStories != 4 || r.WithFrontmatter != 2 || r.WithoutFrontmatter != 2 {
+		t.Fatalf("coverage = %+v, want 4/2/2", r)
+	}
+	if len(r.UnannotatedStoryIDs) != 2 || r.UnannotatedStoryIDs[0] != "10.1" {
+		t.Errorf("UnannotatedStoryIDs = %v", r.UnannotatedStoryIDs)
+	}
+}
+
+func TestFilterByScope_RestrictsToOneEpic(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "1.1"}},
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "1.2"}},
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "10.1"}}, // off-by-one trap
+		{Frontmatter: sprint.StoryFrontmatter{StoryID: "2.1"}},
+	}
+	got := sprint.FilterByScope(parsed, "1")
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (1.1 + 1.2 only)", len(got))
+	}
+	if got[0].Frontmatter.StoryID != "1.1" || got[1].Frontmatter.StoryID != "1.2" {
+		t.Errorf("filtered ids = %q,%q; want 1.1,1.2",
+			got[0].Frontmatter.StoryID, got[1].Frontmatter.StoryID)
+	}
+	// Empty scope leaves slice intact.
+	if all := sprint.FilterByScope(parsed, ""); len(all) != 4 {
+		t.Errorf("empty scope dropped stories: got %d, want 4", len(all))
+	}
 }

--- a/application/sprint/planner.go
+++ b/application/sprint/planner.go
@@ -25,12 +25,60 @@ type Planner struct {
 
 // IngestResult summarises a Plan call.
 type IngestResult struct {
-	StoriesInserted    int   `json:"stories_inserted"`
-	StoriesUpdated     int   `json:"stories_updated"`
-	DependenciesAdded  int   `json:"dependencies_added"`
-	AffectsAdded       int   `json:"affects_added"`
-	BatchesCreated     int   `json:"batches_created"`
+	StoriesInserted    int     `json:"stories_inserted"`
+	StoriesUpdated     int     `json:"stories_updated"`
+	DependenciesAdded  int     `json:"dependencies_added"`
+	AffectsAdded       int     `json:"affects_added"`
+	BatchesCreated     int     `json:"batches_created"`
 	BatchIDs           []int64 `json:"batch_ids"`
+	// Scope, when non-empty, is the epic-id filter that was applied. Stories
+	// outside this scope were skipped entirely.
+	Scope              string  `json:"scope,omitempty"`
+	// StoriesSkippedByScope counts how many parsed stories were excluded
+	// because they don't belong to the requested --scope.
+	StoriesSkippedByScope int `json:"stories_skipped_by_scope,omitempty"`
+}
+
+// CoverageReport summarises frontmatter coverage of a parsed epics set —
+// surfaced by the CLI so an operator can decide whether to proceed against
+// partially-annotated epics or backfill first.
+type CoverageReport struct {
+	TotalStories          int      `json:"total_stories"`
+	WithFrontmatter       int      `json:"with_frontmatter"`
+	WithoutFrontmatter    int      `json:"without_frontmatter"`
+	UnannotatedStoryIDs   []string `json:"unannotated_story_ids,omitempty"`
+}
+
+// AnalyseCoverage builds a CoverageReport over the parsed stories. Cheap
+// (single pass, no IO) — called by the CLI to decide whether to surface a
+// partial-coverage warning before delegating to Plan.
+func AnalyseCoverage(parsed []ParsedStory) CoverageReport {
+	r := CoverageReport{TotalStories: len(parsed)}
+	for _, ps := range parsed {
+		if ps.HasFrontmatter {
+			r.WithFrontmatter++
+			continue
+		}
+		r.WithoutFrontmatter++
+		r.UnannotatedStoryIDs = append(r.UnannotatedStoryIDs, ps.Frontmatter.StoryID)
+	}
+	return r
+}
+
+// FilterByScope returns only the stories whose ID belongs to epicID. An empty
+// epicID returns the slice unchanged. See StoryMatchesEpic for the matching
+// rule (prefix + dot; avoids the "1" / "10" off-by-one footgun).
+func FilterByScope(parsed []ParsedStory, epicID string) []ParsedStory {
+	if epicID == "" {
+		return parsed
+	}
+	out := make([]ParsedStory, 0, len(parsed))
+	for _, ps := range parsed {
+		if StoryMatchesEpic(ps.Frontmatter.StoryID, epicID) {
+			out = append(out, ps)
+		}
+	}
+	return out
 }
 
 // Plan persists parsed stories + builds batches. Clears any existing planned

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,20 +13,41 @@ import (
 	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
 )
 
-// newConfigCmd implements `bmad config <key> [<value>]`:
+// configFootgunKeys are the stray keys the pre-#16 ambiguous-positional CLI
+// could accidentally write. We surface a one-time warning when the state DB
+// holds any of them — making the cleanup discoverable without forcing a
+// destructive migration. See issue #16.
+var configFootgunKeys = []string{"get", "set"}
+
+// newConfigCmd implements `bmad config <verb> ...`:
 //
-//   - no args: list all config rows
-//   - one arg (key): print value, exit 1 if unset
-//   - two args (key, value): upsert
+//   - `bmad config`                — list all rows
+//   - `bmad config get <key>`      — read-only; never writes
+//   - `bmad config set <key> <v>`  — write-only; requires both args
+//   - `bmad config audit`          — surfaces any orphan keys from the
+//                                    old ambiguous-positional footgun
+//
+// Pre-#16 forms (`bmad config foo bar` writing foo=bar; `bmad config foo`
+// reading foo) accidentally let the L1 orchestrator create a stray "get"
+// key — see issue #16. We now refuse positional misuse and route through
+// explicit verbs.
 func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config [<key>] [<value>]",
-		Short: "Get or set runtime config (sqlite-backed)",
-		Long: `Three forms:
-  bmad config                  # list all keys (tabular)
-  bmad config <key>            # print value for key
-  bmad config <key> <value>    # upsert key=value`,
-		Args: cobra.MaximumNArgs(2),
+		Use:   "config <verb>",
+		Short: "Runtime config (sqlite-backed) — list / get / set / audit",
+		Long: `Subcommands:
+  bmad config              # list all keys
+  bmad config get <key>    # print value (read-only; never writes)
+  bmad config set <k> <v>  # upsert key=value (write-only; requires both args)
+  bmad config audit        # report orphan keys from the pre-#16 footgun
+
+The previous "bmad config <key> [<value>]" positional form is removed —
+it let the L1 accidentally write a stray "get" key by mis-ordering args
+(issue #16). Use the explicit verbs.`,
+		// No Args: cobra.MaximumNArgs(...) at the parent — bare `bmad config`
+		// listing is the only positional form, handled by RunE below; all
+		// other paths go through the verb subcommands.
+		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
 			db, err := openV6DB(ctx)
@@ -35,20 +56,134 @@ func newConfigCmd() *cobra.Command {
 			}
 			defer db.Close()
 			cfg := sqlite.NewConfigStore(db)
+			warnConfigFootguns(ctx, cfg)
+			return listAllConfig(ctx, cfg)
+		},
+	}
+	cmd.AddCommand(
+		newConfigGetCmd(),
+		newConfigSetCmd(),
+		newConfigAuditCmd(),
+	)
+	addV6PersistentFlags(cmd)
+	return cmd
+}
 
-			switch len(args) {
-			case 0:
-				return listAllConfig(ctx, cfg)
-			case 1:
-				return getOneConfig(ctx, cfg, args[0])
-			case 2:
-				return setOneConfig(ctx, cfg, args[0], args[1])
+func newConfigGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Read a config value (never writes)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			db, err := openV6DB(ctx)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			cfg := sqlite.NewConfigStore(db)
+			warnConfigFootguns(ctx, cfg)
+			return getOneConfig(ctx, cfg, args[0])
+		},
+	}
+}
+
+func newConfigSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Upsert a config row (requires both args)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			db, err := openV6DB(ctx)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			cfg := sqlite.NewConfigStore(db)
+			warnConfigFootguns(ctx, cfg)
+			return setOneConfig(ctx, cfg, args[0], args[1])
+		},
+	}
+}
+
+func newConfigAuditCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "audit",
+		Short: "Report orphan keys left over from the pre-#16 ambiguous-positional CLI",
+		Long: `Scans the config table for keys that match the footgun pattern
+(e.g. "get", "set" — these were never meant to be stored values
+but the pre-#16 CLI's positional form could create them). Prints
+the matches with their values + suggested cleanup commands.
+
+Non-destructive: this command only reads. Use ` + "`bmad config set`" + `
+or a direct sqlite DELETE to remove them after review.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			db, err := openV6DB(ctx)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			cfg := sqlite.NewConfigStore(db)
+			orphans, err := findConfigFootguns(ctx, cfg)
+			if err != nil {
+				return err
+			}
+			if len(orphans) == 0 {
+				fmt.Println("config audit: clean (no orphan keys matching the #16 footgun pattern)")
+				return nil
+			}
+			fmt.Printf("config audit: %d orphan key(s) found — likely from the pre-#16 ambiguous-positional CLI:\n\n", len(orphans))
+			for _, e := range orphans {
+				fmt.Printf("  %s = %q   (updated %s)\n", e.Key, e.Value, e.UpdatedAt.Format("2006-01-02 15:04:05"))
+			}
+			fmt.Println()
+			fmt.Println("Suggested cleanup (review before running):")
+			for _, e := range orphans {
+				fmt.Printf("  sqlite3 bmad-state.db \"DELETE FROM config WHERE key = '%s';\"\n", e.Key)
 			}
 			return nil
 		},
 	}
-	addV6PersistentFlags(cmd)
-	return cmd
+}
+
+// findConfigFootguns returns ConfigEntry rows whose key matches the pre-#16
+// footgun list. Empty slice when the DB is clean.
+func findConfigFootguns(ctx context.Context, cfg state.Config) ([]state.ConfigEntry, error) {
+	all, err := cfg.All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	want := make(map[string]bool, len(configFootgunKeys))
+	for _, k := range configFootgunKeys {
+		want[k] = true
+	}
+	var out []state.ConfigEntry
+	for _, e := range all {
+		if want[e.Key] {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// warnConfigFootguns emits a one-line stderr nudge when a footgun key is
+// present in the DB. Best-effort — if the audit itself errors, stay quiet so
+// the parent command doesn't fail noisily on a diagnostic.
+func warnConfigFootguns(ctx context.Context, cfg state.Config) {
+	orphans, err := findConfigFootguns(ctx, cfg)
+	if err != nil || len(orphans) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(orphans))
+	for _, e := range orphans {
+		keys = append(keys, e.Key)
+	}
+	fmt.Fprintf(os.Stderr,
+		"NOTE: config table has %d orphan key(s) (%v) likely from the pre-#16 ambiguous-positional CLI. "+
+			"Run `bmad config audit` for cleanup commands.\n",
+		len(orphans), keys)
 }
 
 func listAllConfig(ctx context.Context, cfg state.Config) error {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// Issue #16: orphan-key audit detects the pre-fix footgun residue. The
+// pre-#16 CLI's positional "bmad config get mode" form could accidentally
+// write a stray "get" key (treating "get" as the key and "mode" as the
+// value). We surface those for cleanup without a destructive migration.
+func TestFindConfigFootguns_DetectsOrphanKeys(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "bmad-state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	cfg := sqlite.NewConfigStore(db)
+
+	// Seed normal config + the footgun orphans.
+	for _, kv := range []struct{ k, v string }{
+		{"mode", "pragmatic"},      // legitimate
+		{"max_parallel", "4"},      // legitimate
+		{"get", "mode"},            // footgun residue
+		{"set", "mode pragmatic"},  // footgun residue
+	} {
+		if err := cfg.Set(ctx, kv.k, kv.v); err != nil {
+			t.Fatalf("seed %s: %v", kv.k, err)
+		}
+	}
+
+	orphans, err := findConfigFootguns(ctx, cfg)
+	if err != nil {
+		t.Fatalf("findConfigFootguns: %v", err)
+	}
+	if len(orphans) != 2 {
+		t.Fatalf("orphans = %d, want 2; got %+v", len(orphans), orphans)
+	}
+	// Confirm we got the footguns, NOT the legitimate keys.
+	for _, e := range orphans {
+		if e.Key != "get" && e.Key != "set" {
+			t.Errorf("unexpected orphan key %q", e.Key)
+		}
+	}
+}
+
+// A clean DB → no orphans → no warning. Asymmetric to the positive case
+// because the bare-DB path is what every freshly-init'd repo sees.
+func TestFindConfigFootguns_CleanDBReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "bmad-state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	cfg := sqlite.NewConfigStore(db)
+
+	if err := cfg.Set(ctx, "mode", "pragmatic"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	orphans, err := findConfigFootguns(ctx, cfg)
+	if err != nil {
+		t.Fatalf("findConfigFootguns: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Errorf("clean DB: got %d orphans, want 0", len(orphans))
+	}
+}
+
+// Issue #16: the get verb must read-only and never accidentally write.
+// We exercise this by building the cmd, running get against an unset key,
+// and confirming the DB is unchanged.
+func TestConfigGet_NeverWrites(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "bmad-state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	cfg := sqlite.NewConfigStore(db)
+
+	// Snapshot config before "get".
+	before, _ := cfg.All(ctx)
+	beforeLen := len(before)
+
+	// Call getOneConfig with a missing key wrapped in a defer/recover —
+	// the function calls os.Exit(1) on missing keys, which we can't catch
+	// without spawning a subprocess. Instead, set a value first to avoid
+	// the exit path, then read it back.
+	if err := cfg.Set(ctx, "mode", "pragmatic"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := getOneConfig(ctx, cfg, "mode"); err != nil {
+		t.Fatalf("getOneConfig: %v", err)
+	}
+
+	after, _ := cfg.All(ctx)
+	// One legitimate Set above → exactly one more row than the starting
+	// snapshot (and definitely no "get" / "set" footgun keys).
+	if len(after) != beforeLen+1 {
+		t.Errorf("get path mutated config table: before=%d, after=%d", beforeLen, len(after))
+	}
+	for _, e := range after {
+		if e.Key == "get" || e.Key == "set" {
+			t.Errorf("footgun key %q present after get-only path", e.Key)
+		}
+	}
+}

--- a/cmd/dispatch.go
+++ b/cmd/dispatch.go
@@ -152,6 +152,7 @@ func newDispatchRecordCmd() *cobra.Command {
 		outputTokens int64
 		cacheRead    int64
 		cacheCreate  int64
+		totalTokens  int64
 		model        string
 		durationMS   int64
 		idemKey      string
@@ -168,7 +169,14 @@ func newDispatchRecordCmd() *cobra.Command {
   bmad dispatch record <story-id> <stage> <status>
     Legacy form that inserts a fresh row without key. Useful for
     one-off records (e.g. manual entries); does NOT participate in
-    crash-recovery reconciliation.`,
+    crash-recovery reconciliation.
+
+Token accounting (issue #15): pass the four breakdown axes
+(--input-tokens, --output-tokens, --cache-read-tokens,
+--cache-create-tokens) when the subagent's <usage> block provides
+them — this is what powers the cache_hit_rate column in
+` + "`bmad sprint status`" + `. ` + "`--total-tokens`" + ` is kept for backward compat:
+provide either form, or both (the latter validates the sum).`,
 		Args: cobra.MaximumNArgs(3),
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -179,6 +187,24 @@ func newDispatchRecordCmd() *cobra.Command {
 			defer db.Close()
 			store := sqlite.NewDispatchesStore(db)
 			now := time.Now().UTC()
+
+			// Issue #15: reconcile --total-tokens with the 4-axis breakdown.
+			totalProvided := c.Flags().Changed("total-tokens")
+			breakdownProvided := c.Flags().Changed("input-tokens") ||
+				c.Flags().Changed("output-tokens") ||
+				c.Flags().Changed("cache-read-tokens") ||
+				c.Flags().Changed("cache-create-tokens")
+			reconciled, rerr := reconcileTokenInputs(
+				totalProvided, breakdownProvided,
+				totalTokens, inputTokens, outputTokens, cacheRead, cacheCreate,
+			)
+			if rerr != nil {
+				return fmt.Errorf("dispatch record: %w", rerr)
+			}
+			inputTokens = reconciled.Input
+			outputTokens = reconciled.Output
+			cacheRead = reconciled.CacheRead
+			cacheCreate = reconciled.CacheCreate
 
 			// Key-based form (preferred).
 			if idemKey != "" {
@@ -256,9 +282,46 @@ func newDispatchRecordCmd() *cobra.Command {
 	cmd.Flags().Int64Var(&outputTokens, "output-tokens", 0, "output token count")
 	cmd.Flags().Int64Var(&cacheRead, "cache-read-tokens", 0, "cache-read token count")
 	cmd.Flags().Int64Var(&cacheCreate, "cache-create-tokens", 0, "cache-create token count")
+	cmd.Flags().Int64Var(&totalTokens, "total-tokens", 0, "deprecated: total tokens (use the 4 breakdown flags instead; issue #15)")
 	cmd.Flags().StringVar(&model, "model", "", "model identifier")
 	cmd.Flags().Int64Var(&durationMS, "duration-ms", 0, "dispatch wall-clock duration in ms")
 	return cmd
+}
+
+// cacheHitRate returns cache_read / (input + cache_read) as a percentage
+// (0..100, float64). Returns 0 when the denominator is 0.
+func cacheHitRate(t state.TokenCounts) float64 {
+	denom := t.Input + t.CacheRead
+	if denom <= 0 {
+		return 0
+	}
+	return float64(t.CacheRead) / float64(denom) * 100.0
+}
+
+// reconcileTokenInputs decides what (input, output, cache-read, cache-create)
+// to persist given the flags the caller actually set.
+//
+// Issue #15: --total-tokens stays available for backward compat. Legacy
+// callers that pass only --total-tokens get their value bucketed into
+// input_tokens so cumulative dashboards still reflect cost; cache_hit_rate
+// reads 0 until they upgrade to the breakdown flags. If both forms are
+// provided, the sum MUST match — that's the contract the L1 orchestrator
+// relies on to confirm its <usage> parse is correct.
+func reconcileTokenInputs(
+	totalProvided, breakdownProvided bool,
+	total, input, output, cacheRead, cacheCreate int64,
+) (state.TokenCounts, error) {
+	sum := input + output + cacheRead + cacheCreate
+	switch {
+	case totalProvided && breakdownProvided:
+		if total != sum {
+			return state.TokenCounts{}, fmt.Errorf("--total-tokens=%d ≠ input+output+cache-read+cache-create=%d (provide one or the other, or make them agree)",
+				total, sum)
+		}
+	case totalProvided && !breakdownProvided:
+		input = total
+	}
+	return state.TokenCounts{Input: input, Output: output, CacheRead: cacheRead, CacheCreate: cacheCreate}, nil
 }
 
 // agentRoleForStage returns the canonical L3 agent name for a stage.

--- a/cmd/dispatch_test.go
+++ b/cmd/dispatch_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+)
+
+// Issue #15: cache_hit_rate = cache_read / (input + cache_read) — derived from
+// the 4-axis breakdown the subagent's <usage> block provides.
+func TestCacheHitRate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   state.TokenCounts
+		want float64
+	}{
+		// Zero denominator: no input AND no cache_read — undefined, so
+		// return 0 rather than divide-by-zero panic / NaN.
+		{"empty", state.TokenCounts{}, 0.0},
+		{"only-output-and-create", state.TokenCounts{Output: 1000, CacheCreate: 500}, 0.0},
+
+		{"all-fresh", state.TokenCounts{Input: 100, CacheRead: 0}, 0.0},
+		{"perfect-cache", state.TokenCounts{Input: 0, CacheRead: 100}, 100.0},
+		{"fifty-fifty", state.TokenCounts{Input: 50, CacheRead: 50}, 50.0},
+		{"realistic", state.TokenCounts{Input: 1000, CacheRead: 9000, Output: 500, CacheCreate: 200}, 90.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := cacheHitRate(tc.in)
+			if math.Abs(got-tc.want) > 0.001 {
+				t.Errorf("cacheHitRate(%+v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Issue #15: --total-tokens must validate against the breakdown sum when both
+// forms are provided. Asserted via the record command's flag-parsing path —
+// here we just exercise the math the validator relies on.
+func TestTokenBreakdownSumsMatchTotal(t *testing.T) {
+	t.Parallel()
+	t1 := state.TokenCounts{Input: 100, Output: 200, CacheRead: 300, CacheCreate: 50}
+	got := t1.Input + t1.Output + t1.CacheRead + t1.CacheCreate
+	if got != 650 {
+		t.Fatalf("breakdown sum = %d, want 650", got)
+	}
+}
+
+// Issue #15: reconcileTokenInputs decides what to persist when the caller
+// mixes legacy --total-tokens with the new 4-axis breakdown flags. The four
+// cases the L1 orchestrator actually exercises:
+//
+//   - new caller (breakdown only)        → use breakdown as-is
+//   - legacy caller (total only)         → bucket total into input
+//   - both, sums agree                   → use breakdown (total is redundant)
+//   - both, sums disagree                → error (the validator caught a bug)
+func TestReconcileTokenInputs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		total     bool
+		breakdown bool
+		tot       int64
+		i, o, cr, cc int64
+		want      state.TokenCounts
+		wantErr   bool
+	}{
+		{
+			name:      "breakdown-only",
+			breakdown: true,
+			i: 100, o: 200, cr: 300, cc: 50,
+			want: state.TokenCounts{Input: 100, Output: 200, CacheRead: 300, CacheCreate: 50},
+		},
+		{
+			name:  "total-only-buckets-to-input",
+			total: true,
+			tot:   650,
+			want:  state.TokenCounts{Input: 650},
+		},
+		{
+			name:      "both-agree",
+			total:     true,
+			breakdown: true,
+			tot:       650,
+			i: 100, o: 200, cr: 300, cc: 50,
+			want: state.TokenCounts{Input: 100, Output: 200, CacheRead: 300, CacheCreate: 50},
+		},
+		{
+			name:      "both-disagree-errors",
+			total:     true,
+			breakdown: true,
+			tot:       9999,
+			i: 100, o: 200, cr: 300, cc: 50,
+			wantErr: true,
+		},
+		{
+			name: "neither-zeroes",
+			want: state.TokenCounts{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := reconcileTokenInputs(tc.total, tc.breakdown, tc.tot, tc.i, tc.o, tc.cr, tc.cc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; got=%+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -294,6 +294,17 @@ func newSprintStatusCmd() *cobra.Command {
 			paused, _ := cfg.Get(ctx, sprintPausedKey)
 			mode, _ := cfg.Get(ctx, "mode")
 
+			// Issue #15: surface the 4-axis breakdown + cache_hit_rate so
+			// downstream dashboards can see cache health at a glance.
+			tokenBreakdown := map[string]any{
+				"input":           tokens.Input,
+				"output":          tokens.Output,
+				"cache_read":      tokens.CacheRead,
+				"cache_create":    tokens.CacheCreate,
+				"total":           tokens.Input + tokens.Output + tokens.CacheRead + tokens.CacheCreate,
+				"cache_hit_rate":  cacheHitRate(tokens),
+			}
+
 			report := map[string]any{
 				"mode":             mode,
 				"paused":           paused == "true",
@@ -301,7 +312,7 @@ func newSprintStatusCmd() *cobra.Command {
 				"by_status":        counts,
 				"batches":          batchSummary,
 				"unresolved_checkpoint": unresolved,
-				"tokens":           tokens,
+				"tokens":           tokenBreakdown,
 			}
 			if raw {
 				return json.NewEncoder(os.Stdout).Encode(report)
@@ -334,6 +345,8 @@ func printSprintTable(report map[string]any, counts, batches map[string]int, tok
 	fmt.Fprintf(w, "  output\t%d\n", tokens.Output)
 	fmt.Fprintf(w, "  cache read\t%d\n", tokens.CacheRead)
 	fmt.Fprintf(w, "  cache create\t%d\n", tokens.CacheCreate)
+	fmt.Fprintf(w, "  total\t%d\n", tokens.Input+tokens.Output+tokens.CacheRead+tokens.CacheCreate)
+	fmt.Fprintf(w, "  cache hit rate\t%.1f%%\n", cacheHitRate(tokens))
 	if cp, ok := report["unresolved_checkpoint"].(*state.Checkpoint); ok && cp != nil {
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "UNRESOLVED CHECKPOINT — run `bmad sprint resume` after deciding")

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -41,12 +41,30 @@ func newSprintCmd() *cobra.Command {
 
 func newSprintPlanCmd() *cobra.Command {
 	var (
-		epicsPath string
-		maxP      int
+		epicsPath        string
+		maxP             int
+		scope            string
+		allowDepsMissing bool
 	)
 	cmd := &cobra.Command{
 		Use:   "plan",
 		Short: "Parse epics.md → ingest stories + dependencies + build batches",
+		Long: `Reads epics.md, ingests stories + dependencies + affects rows, and
+builds a deterministic batch plan respecting topo order, file-overlap
+disjointness, and android-serialization.
+
+Safety rails (issue #14):
+  --scope <epic-id>          Restrict batching to one epic (e.g. --scope 1
+                              picks 1.1, 1.2, …; 10.* is excluded). Useful
+                              when only one epic has full frontmatter and
+                              the rest still needs backfilling.
+
+  --allow-deps-missing       Bypass the partial-coverage warning. By default,
+                              ` + "`bmad sprint plan`" + ` refuses to proceed if any
+                              parsed story lacks YAML frontmatter — without
+                              ` + "`depends_on:`" + ` such stories collapse to topo-level-0
+                              and would be dispatched alongside true Epic-1
+                              top-level work (cross-epic batching bug).`,
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
 			db, err := openV6DB(ctx)
@@ -67,6 +85,37 @@ func newSprintPlanCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Apply --scope filter FIRST so coverage analysis only flags
+			// in-scope stories. A scope restricted to a fully-annotated
+			// epic should not warn on un-annotated epics outside scope.
+			totalBeforeScope := len(parsed)
+			if scope != "" {
+				parsed = appsprint.FilterByScope(parsed, scope)
+				if len(parsed) == 0 {
+					return fmt.Errorf("sprint plan: --scope %q matched zero stories in %s", scope, epicsPath)
+				}
+			}
+
+			// Partial-coverage safety check (issue #14, fix #1).
+			coverage := appsprint.AnalyseCoverage(parsed)
+			if coverage.WithoutFrontmatter > 0 && !allowDepsMissing {
+				preview := coverage.UnannotatedStoryIDs
+				if len(preview) > 8 {
+					preview = preview[:8]
+				}
+				fmt.Fprintf(os.Stderr,
+					"WARN: %d of %d stories have no frontmatter — they'll be treated as topo-level-0.\n"+
+						"      Affected (first %d): %s%s\n"+
+						"      Use --allow-deps-missing to proceed anyway, OR backfill frontmatter first.\n"+
+						"      Tip: --scope <epic-id> restricts to one annotated epic.\n",
+					coverage.WithoutFrontmatter, coverage.TotalStories,
+					len(preview), strings.Join(preview, ", "),
+					moreSuffix(coverage.UnannotatedStoryIDs, preview),
+				)
+				return fmt.Errorf("sprint plan: refusing to plan with %d un-annotated stories (use --allow-deps-missing to override)", coverage.WithoutFrontmatter)
+			}
+
 			if maxP <= 0 {
 				if v, err := cfg.Get(ctx, "max_parallel"); err == nil {
 					if n, _ := strconv.Atoi(v); n > 0 {
@@ -88,12 +137,27 @@ func newSprintPlanCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if scope != "" {
+				res.Scope = scope
+				res.StoriesSkippedByScope = totalBeforeScope - len(parsed)
+			}
 			return json.NewEncoder(os.Stdout).Encode(res)
 		},
 	}
 	cmd.Flags().StringVar(&epicsPath, "epics", "", "epics.md path (default: <docs_folder>/epics.md)")
 	cmd.Flags().IntVar(&maxP, "max-parallel", 0, "override max parallel slots per batch")
+	cmd.Flags().StringVar(&scope, "scope", "", "restrict planning to one epic id (e.g. 1 → only 1.* stories)")
+	cmd.Flags().BoolVar(&allowDepsMissing, "allow-deps-missing", false, "bypass the partial-frontmatter coverage check (issue #14)")
 	return cmd
+}
+
+// moreSuffix renders " (+N more)" when the preview slice is shorter than the
+// full list; empty string otherwise.
+func moreSuffix(full, shown []string) string {
+	if len(full) <= len(shown) {
+		return ""
+	}
+	return fmt.Sprintf(" (+%d more)", len(full)-len(shown))
 }
 
 // ---------- run ----------

--- a/infrastructure/prompts/renderer.go
+++ b/infrastructure/prompts/renderer.go
@@ -115,6 +115,23 @@ func seedOptionalSlots(template string, data map[string]any) {
 		setDefault(data, "PriorAttempt", (*struct{})(nil))
 		setDefault(data, "IdempotencyKey", "")
 	}
+	// Issue #17: doc-only / architectural-decision stories don't need a test
+	// environment. EnvConfig is now optional on the stages that previously
+	// required it; a zero/missing EnvConfig collapses the rendered prompt's
+	// "Test environment" block entirely.
+	//
+	// Two cases the caller might create:
+	//   (a) EnvConfig missing entirely → seed an all-zero map so
+	//       `{{.EnvConfig.PgPort}}` resolves under missingkey=error
+	//   (b) EnvConfig present as a partial map → backfill the missing
+	//       port keys with 0 so `{{if .EnvConfig.RedisPort}}` is false
+	//       instead of erroring
+	// Typed-struct callers (`type envCfg struct{ PgPort, RedisPort int }`)
+	// don't need this treatment — missing struct fields are zero, not errors.
+	switch template {
+	case "stage_implement", "stage_atdd", "stage_automate", "stage_test_review", "stage_code_review":
+		ensureEnvConfigKeys(data)
+	}
 	switch template {
 	case "stage_hydrate":
 		setDefault(data, "CacheBundlePath", "")
@@ -130,5 +147,34 @@ func seedOptionalSlots(template string, data map[string]any) {
 func setDefault(m map[string]any, key string, value any) {
 	if _, ok := m[key]; !ok {
 		m[key] = value
+	}
+}
+
+// ensureEnvConfigKeys backfills .EnvConfig's port-keys with zero values so
+// the stage_* templates can use `{{if .EnvConfig.PgPort}}` under
+// missingkey=error without erroring on a partial map.
+//
+// Only acts when EnvConfig is already a map[string]any (or absent). If the
+// caller passed a typed struct, leave it alone — struct field access doesn't
+// trip missingkey=error.
+func ensureEnvConfigKeys(data map[string]any) {
+	existing, ok := data["EnvConfig"]
+	if !ok {
+		data["EnvConfig"] = map[string]any{
+			"PgPort": 0, "RedisPort": 0, "OtelPort": 0, "DbName": "",
+		}
+		return
+	}
+	m, isMap := existing.(map[string]any)
+	if !isMap {
+		return // typed struct or other shape — caller takes responsibility
+	}
+	for _, k := range []string{"PgPort", "RedisPort", "OtelPort"} {
+		if _, present := m[k]; !present {
+			m[k] = 0
+		}
+	}
+	if _, present := m["DbName"]; !present {
+		m["DbName"] = ""
 	}
 }

--- a/infrastructure/prompts/renderer_test.go
+++ b/infrastructure/prompts/renderer_test.go
@@ -101,3 +101,106 @@ func TestRender_MissingRequiredSlotErrors(t *testing.T) {
 		t.Fatalf("expected error on missing required slot, got nil")
 	}
 }
+
+// Issue #17: a doc-only story (no port allocation) must render cleanly
+// without an EnvConfig, and the resulting prompt must NOT mention
+// Postgres / Redis / OTEL.
+func TestRender_StageImplement_NoEnvConfig_OmitsTestEnvBlock(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	out, err := r.Render("stage_implement", map[string]any{
+		"StoryID":      "1.1",
+		"HydratedFile": "/tmp/1.1.md",
+		"Mode":         "pragmatic",
+		// Deliberately omitting EnvConfig — seedOptionalSlots fills the
+		// zero-port map so the conditional collapses the env block.
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, mustNot := range []string{
+		"Test environment",
+		"PostgreSQL",
+		"Postgres",
+		"Redis",
+		"OTEL",
+	} {
+		if strings.Contains(out, mustNot) {
+			t.Errorf("doc-only prompt still mentions %q\n--- output ---\n%s", mustNot, out)
+		}
+	}
+	// Core blocks still present.
+	for _, want := range []string{"Implement Story 1.1", "/tmp/1.1.md", "pragmatic"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+// Issue #17: a feature story (full EnvConfig) must STILL emit the test
+// environment block — the change is backwards-compatible for the existing
+// dispatch path.
+func TestRender_StageImplement_FullEnvConfig_KeepsTestEnvBlock(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	out, err := r.Render("stage_implement", map[string]any{
+		"StoryID":      "4.1",
+		"HydratedFile": "/tmp/4.1.md",
+		"Mode":         "strict",
+		"EnvConfig": map[string]any{
+			"PgPort":    7611,
+			"RedisPort": 7612,
+			"OtelPort":  7613,
+			"DbName":    "story_4_1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, want := range []string{
+		"Test environment",
+		"PostgreSQL",
+		"7611",
+		"story_4_1",
+		"Redis",
+		"7612",
+		"OTEL",
+		"7613",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("feature-story prompt missing %q", want)
+		}
+	}
+}
+
+// Issue #17 corner case: a story with Postgres only (no Redis / OTEL) —
+// we must NOT emit empty Redis/OTEL bullets, and the heading must remain.
+func TestRender_StageImplement_PgOnly_OmitsRedisAndOtel(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	out, err := r.Render("stage_implement", map[string]any{
+		"StoryID":      "5.1",
+		"HydratedFile": "/tmp/5.1.md",
+		"Mode":         "pragmatic",
+		"EnvConfig": map[string]any{
+			"PgPort": 7801,
+			"DbName": "story_5_1",
+			// RedisPort, OtelPort intentionally unset.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(out, "Test environment") {
+		t.Errorf("Test environment heading missing\n%s", out)
+	}
+	if !strings.Contains(out, "7801") {
+		t.Errorf("Pg port missing")
+	}
+	if strings.Contains(out, "Redis") {
+		t.Errorf("Redis bullet appeared without a port\n%s", out)
+	}
+	if strings.Contains(out, "OTEL") {
+		t.Errorf("OTEL bullet appeared without a port\n%s", out)
+	}
+}

--- a/infrastructure/prompts/templates/stage_atdd.tmpl
+++ b/infrastructure/prompts/templates/stage_atdd.tmpl
@@ -2,7 +2,8 @@
        .StoryID         (string)   required
        .HydratedFile    (string)   required
        .Mode            (string)   required (always "strict" for this stage)
-       .EnvConfig       (struct)   required
+       .EnvConfig       (struct)   optional — block omitted entirely
+                                    when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
 */}}
@@ -14,13 +15,19 @@ implementation. Red-phase TDD.
 
 Hydrated spec: `{{.HydratedFile}}`
 
+{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
 ## Test environment (already up)
 
+{{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
+{{end -}}
+{{if .EnvConfig.RedisPort -}}
 - Redis :{{.EnvConfig.RedisPort}}
+{{end -}}
 {{if .EnvConfig.OtelPort -}}
 - OTEL :{{.EnvConfig.OtelPort}}
-{{- end}}
+{{end -}}
+{{end}}
 
 {{if .PriorAttempt -}}
 ## Prior attempt summary

--- a/infrastructure/prompts/templates/stage_automate.tmpl
+++ b/infrastructure/prompts/templates/stage_automate.tmpl
@@ -2,7 +2,8 @@
        .StoryID         (string)   required
        .HydratedFile    (string)   required
        .Mode            (string)   required (always "strict" for this stage)
-       .EnvConfig       (struct)   required
+       .EnvConfig       (struct)   optional — block omitted entirely
+                                    when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
 */}}
@@ -15,13 +16,19 @@ coverage that ATDD's high-level focus missed.
 
 Hydrated spec: `{{.HydratedFile}}`
 
+{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
 ## Test environment (already up)
 
+{{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
+{{end -}}
+{{if .EnvConfig.RedisPort -}}
 - Redis :{{.EnvConfig.RedisPort}}
+{{end -}}
 {{if .EnvConfig.OtelPort -}}
 - OTEL :{{.EnvConfig.OtelPort}}
-{{- end}}
+{{end -}}
+{{end}}
 
 {{if .PriorAttempt -}}
 ## Prior attempt summary

--- a/infrastructure/prompts/templates/stage_code_review.tmpl
+++ b/infrastructure/prompts/templates/stage_code_review.tmpl
@@ -2,7 +2,8 @@
        .StoryID         (string)   required
        .HydratedFile    (string)   required
        .Mode            (string)   required — pragmatic | strict
-       .EnvConfig       (struct)   required
+       .EnvConfig       (struct)   optional — block omitted entirely
+                                    when no port is set (issue #17)
        .Iteration       (int)      required — review iteration #; 1 for first pass
        .MaxIterations   (int)      required — max_review_iterations from config
        .PriorAttempt    (*struct)  optional
@@ -25,9 +26,11 @@ PRAGMATIC: 1 round + advisory findings. Surface issues; do NOT block
 unless they're show-stoppers.
 {{- end}}
 
+{{if .EnvConfig.PgPort -}}
 ## Test environment
 
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
+{{end}}
 
 {{if .PriorAttempt -}}
 ## Prior attempt summary

--- a/infrastructure/prompts/templates/stage_implement.tmpl
+++ b/infrastructure/prompts/templates/stage_implement.tmpl
@@ -2,7 +2,10 @@
        .StoryID                 (string)   required
        .HydratedFile            (string)   required — path on disk
        .Mode                    (string)   required — pragmatic | strict
-       .EnvConfig               (struct)   required — {PgPort, RedisPort, OtelPort, DbName}
+       .EnvConfig               (struct)   optional — {PgPort, RedisPort, OtelPort, DbName}.
+                                            Empty/zero for doc-only or architectural-decision
+                                            stories — the "Test environment" block is then
+                                            omitted entirely (issue #17).
        .StoryContextBundlePath  (string)   optional — per-story curated bundle.
                                            Auto-populated when
                                            _bmad-output/context-bundles/<id>.md
@@ -25,13 +28,19 @@ already consumed this file; if you need quick reminders of the spec's
 "why" without re-reading the full hydrated file, skim here.
 {{- end}}
 
+{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
 ## Test environment (already up — do NOT recreate)
 
+{{if .EnvConfig.PgPort -}}
 - PostgreSQL on `:{{.EnvConfig.PgPort}}`  (db: `{{.EnvConfig.DbName}}`)
+{{end -}}
+{{if .EnvConfig.RedisPort -}}
 - Redis on `:{{.EnvConfig.RedisPort}}`
+{{end -}}
 {{if .EnvConfig.OtelPort -}}
 - OTEL on `:{{.EnvConfig.OtelPort}}`
-{{- end}}
+{{end -}}
+{{end}}
 
 {{if .PriorAttempt -}}
 ## Prior attempt summary

--- a/infrastructure/prompts/templates/stage_test_review.tmpl
+++ b/infrastructure/prompts/templates/stage_test_review.tmpl
@@ -2,7 +2,8 @@
        .StoryID         (string)   required
        .HydratedFile    (string)   required
        .Mode            (string)   required (always "strict" for this stage)
-       .EnvConfig       (struct)   required
+       .EnvConfig       (struct)   optional — block omitted entirely
+                                    when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
 */}}
@@ -15,13 +16,19 @@ naming, coverage, anti-patterns. Score 0-100.
 
 Hydrated spec: `{{.HydratedFile}}`
 
+{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
 ## Test environment
 
+{{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
+{{end -}}
+{{if .EnvConfig.RedisPort -}}
 - Redis :{{.EnvConfig.RedisPort}}
+{{end -}}
 {{if .EnvConfig.OtelPort -}}
 - OTEL :{{.EnvConfig.OtelPort}}
-{{- end}}
+{{end -}}
+{{end}}
 
 {{if .PriorAttempt -}}
 ## Prior attempt summary


### PR DESCRIPTION
## Summary

Four fixes from the Epic 1 retrospective (Stories 1.1-1.4, 2026-05-18). Each in its own commit.

- **#14** — \`bmad sprint plan\` warns on partial frontmatter coverage + new \`--scope <epic-id>\` flag
- **#15** — \`bmad dispatch record\` parses input/output/cache-read/cache-create token breakdown; \`bmad sprint status\` surfaces cache_hit_rate
- **#16** — \`bmad config get|set\` requires explicit subcommands; orphan-key warning on startup if state DB has the old footgun pattern
- **#17** — dispatch templates wrap test-env block in EnvConfig conditionals so doc-only stories don't need phantom port allocations

## Pickup note

This PR was the work of a background agent that crashed at the very end (socket error during commit of issue #17). I picked up, verified the templates diff + tests, committed, pushed. All 3 prior commits and tests landed cleanly during the agent's run.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] All 10 packages pass on the final HEAD (\`576491a\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)