### PR TITLE
fix(cache): diagnose + restructure templates for prompt cache invariance (closes #20)

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -23,13 +24,14 @@ import (
 //   3. config defaults (lowest — mode, max_parallel, reserve_ram_mb)
 func newRenderCmd() *cobra.Command {
 	var (
-		dataJSON  string
-		storyID   string
-		envStory  string
-		stageFlag string
-		attempt   int
-		mode      string
-		outPath   string
+		dataJSON          string
+		storyID           string
+		envStory          string
+		stageFlag         string
+		attempt           int
+		mode              string
+		outPath           string
+		debugCachePrefix  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "render <template-name>",
@@ -98,6 +100,10 @@ func newRenderCmd() *cobra.Command {
 				return err
 			}
 
+			if debugCachePrefix {
+				out = annotateCacheBoundary(out)
+			}
+
 			if outPath != "" {
 				if err := os.WriteFile(outPath, []byte(out), 0o644); err != nil {
 					return fmt.Errorf("write --out %s: %w", outPath, err)
@@ -115,9 +121,48 @@ func newRenderCmd() *cobra.Command {
 	cmd.Flags().IntVar(&attempt, "attempt", 1, "attempt number (used by retry_context)")
 	cmd.Flags().StringVar(&mode, "mode", "", "mode override (defaults to config.mode)")
 	cmd.Flags().StringVar(&outPath, "out", "", "write to file instead of stdout")
+	cmd.Flags().BoolVar(&debugCachePrefix, "debug-cache-prefix", false, "annotate the cache-boundary in the rendered output (issue #20). The stable PREFIX (cache-eligible — byte-identical across dispatches of this stage) is wrapped with `=== STABLE PREFIX ===` markers; the variable SUFFIX (per-story slot data — cache-busts each dispatch) is wrapped with `=== VARIABLE SUFFIX ===` markers. Used for diagnosing prompt-cache hit-rate issues.")
 	cmd.Flags().String("idempotency-key", "", "idempotency key from `dispatch begin` — injected into the rendered prompt so the L3 agent echoes it back")
 	addV6PersistentFlags(cmd)
 	return cmd
+}
+
+// cacheBoundaryMarker matches the literal HEADING line every stage_*.tmpl
+// uses to open its per-story suffix. The marker doubles as the cache
+// boundary: every byte before the marker is stable across dispatches of the
+// same stage; every byte from the marker onward is per-story.
+//
+// The marker is anchored with a leading newline so prose mentions of the
+// section name (e.g. `read "## Story dispatch" last`) inside the stable
+// prefix don't get matched.
+//
+// For non-stage templates (orchestrator_loop, retry_context), there is no
+// boundary — the entire template is either cache-stable (orchestrator_loop
+// is per-session-stable) or always nested inside another template
+// (retry_context). We surface the whole text as "stable" in that case.
+const cacheBoundaryMarker = "\n## Story dispatch\n"
+
+// annotateCacheBoundary wraps the rendered output with explicit STABLE PREFIX
+// / VARIABLE SUFFIX markers so operators can see exactly where the prompt
+// stops being cache-eligible.
+func annotateCacheBoundary(rendered string) string {
+	idx := strings.Index(rendered, cacheBoundaryMarker)
+	if idx < 0 {
+		// No marker means the template isn't a per-story stage — treat the
+		// whole thing as the stable prefix.
+		return "=== STABLE PREFIX (cache-eligible — no per-story variance) ===\n" +
+			rendered +
+			"\n=== END (no variable suffix) ===\n"
+	}
+	// Include the leading newline in the prefix so the suffix starts at the
+	// "## Story dispatch" heading itself.
+	prefix := rendered[:idx+1]
+	suffix := rendered[idx+1:]
+	return "=== STABLE PREFIX (cache-eligible — byte-identical across dispatches of this stage) ===\n" +
+		prefix +
+		"=== VARIABLE SUFFIX (per-story — cache-busts here onward) ===\n" +
+		suffix +
+		"=== END ===\n"
 }
 
 func needsConfigDefaults(template string) bool {

--- a/infrastructure/prompts/renderer_test.go
+++ b/infrastructure/prompts/renderer_test.go
@@ -130,7 +130,7 @@ func TestRender_StageImplement_NoEnvConfig_OmitsTestEnvBlock(t *testing.T) {
 		}
 	}
 	// Core blocks still present.
-	for _, want := range []string{"Implement Story 1.1", "/tmp/1.1.md", "pragmatic"} {
+	for _, want := range []string{"Implement", "Story ID: **1.1**", "/tmp/1.1.md", "pragmatic"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("prompt missing %q", want)
 		}
@@ -202,5 +202,237 @@ func TestRender_StageImplement_PgOnly_OmitsRedisAndOtel(t *testing.T) {
 	}
 	if strings.Contains(out, "OTEL") {
 		t.Errorf("OTEL bullet appeared without a port\n%s", out)
+	}
+}
+
+// Issue #20: cache-invariance contract.
+//
+// Anthropic's prompt cache requires a byte-identical prefix across dispatches
+// for cache_read_input_tokens > 0. Epic 1 + Epic 2 batch 1 baseline saw 0%
+// cache hits across 1.25M input tokens because the templates put per-story
+// variable data (StoryID, HydratedFile, EnvConfig) at the TOP — the cache
+// boundary broke at line 1.
+//
+// The restructure (this PR) moves the stable per-stage content (protocol,
+// atlas guide, return-JSON schema) to a PREFIX, marked off with the literal
+// cache-boundary comment marker, and pushes per-story slots into a SUFFIX
+// under "## Story dispatch".
+//
+// These tests lock in the invariance: rendering the same stage with two
+// different stories must produce IDENTICAL bytes up through the cache
+// boundary marker, then diverge.
+
+// stageCacheBoundaryMarker is the heading every stage_*.tmpl uses to open
+// its per-story SUFFIX. The marker is anchored on `\n## Story dispatch\n`
+// (start-of-line + end-of-line) so prose mentions of the section name
+// inside the prefix don't false-match. This must stay in sync with
+// cmd/render.go's cacheBoundaryMarker constant.
+const stageCacheBoundaryMarker = "\n## Story dispatch\n"
+
+func extractStablePrefix(t *testing.T, rendered string) string {
+	t.Helper()
+	idx := strings.Index(rendered, stageCacheBoundaryMarker)
+	if idx < 0 {
+		t.Fatalf("rendered output missing cache-boundary marker %q — template not restructured\n---\n%s",
+			stageCacheBoundaryMarker, rendered)
+	}
+	// Include the leading newline so the prefix ends naturally.
+	return rendered[:idx+1]
+}
+
+func TestRender_CacheInvariance_StageImplement_PrefixStableAcrossStories(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	a, err := r.Render("stage_implement", map[string]any{
+		"StoryID":      "1.1",
+		"HydratedFile": "/abs/path/to/1.1.md",
+		"Mode":         "pragmatic",
+		"EnvConfig": map[string]any{
+			"PgPort": 7611, "RedisPort": 7612, "OtelPort": 7613, "DbName": "story_1_1",
+		},
+		"IdempotencyKey": "key-aaaa-1111",
+	})
+	if err != nil {
+		t.Fatalf("render A: %v", err)
+	}
+	b, err := r.Render("stage_implement", map[string]any{
+		"StoryID":      "4.7",
+		"HydratedFile": "/different/path/4.7.md",
+		"Mode":         "strict",
+		"EnvConfig": map[string]any{
+			"PgPort": 7801, "RedisPort": 7802, "OtelPort": 7803, "DbName": "story_4_7",
+		},
+		"IdempotencyKey": "key-bbbb-2222",
+	})
+	if err != nil {
+		t.Fatalf("render B: %v", err)
+	}
+	prefixA := extractStablePrefix(t, a)
+	prefixB := extractStablePrefix(t, b)
+	if prefixA != prefixB {
+		t.Fatalf("stage_implement prefix diverged across stories — cache invariance broken\n--- A ---\n%s\n--- B ---\n%s",
+			prefixA, prefixB)
+	}
+	// And the SUFFIXES must actually differ — otherwise we accidentally
+	// moved the story-id out of the rendered output entirely.
+	if !strings.Contains(a, "1.1") || !strings.Contains(b, "4.7") {
+		t.Errorf("story ids missing from suffix — rendered output dropped the variable data")
+	}
+}
+
+func TestRender_CacheInvariance_AllStages_PrefixStableAcrossStories(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	// Two distinct slot-data shapes per stage. The variable bits must
+	// shift; everything before the cache-boundary marker must hold.
+	type slotPair struct {
+		stage string
+		a, b  map[string]any
+	}
+	envA := map[string]any{"PgPort": 7611, "RedisPort": 7612, "OtelPort": 7613, "DbName": "story_a"}
+	envB := map[string]any{"PgPort": 7801, "RedisPort": 7802, "OtelPort": 7803, "DbName": "story_b"}
+
+	pairs := []slotPair{
+		{
+			stage: "stage_atdd",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict", "EnvConfig": envA, "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "strict", "EnvConfig": envB, "IdempotencyKey": "k2"},
+		},
+		{
+			stage: "stage_automate",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict", "EnvConfig": envA, "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "strict", "EnvConfig": envB, "IdempotencyKey": "k2"},
+		},
+		{
+			stage: "stage_test_review",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict", "EnvConfig": envA, "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "strict", "EnvConfig": envB, "IdempotencyKey": "k2"},
+		},
+		{
+			stage: "stage_code_review",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic", "Iteration": 1, "MaxIterations": 3, "EnvConfig": envA, "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "pragmatic", "Iteration": 2, "MaxIterations": 3, "EnvConfig": envB, "IdempotencyKey": "k2"},
+		},
+		{
+			stage: "stage_commit",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic", "Branch": "fix/x-1", "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "pragmatic", "Branch": "fix/y-2", "IdempotencyKey": "k2"},
+		},
+		{
+			stage: "stage_hydrate",
+			a: map[string]any{
+				"StoryID": "1.1", "Mode": "pragmatic",
+				"EpicsPath": "/p/epics.md", "ArchitecturePath": "/p/arch.md",
+				"HydratedFile": "/p/1.1.md", "IdempotencyKey": "k1",
+			},
+			b: map[string]any{
+				"StoryID": "9.9", "Mode": "strict",
+				"EpicsPath": "/q/epics.md", "ArchitecturePath": "/q/arch.md",
+				"HydratedFile": "/q/9.9.md", "IdempotencyKey": "k2",
+			},
+		},
+		{
+			stage: "stage_implement",
+			a: map[string]any{"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic", "EnvConfig": envA, "IdempotencyKey": "k1"},
+			b: map[string]any{"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "strict", "EnvConfig": envB, "IdempotencyKey": "k2"},
+		},
+	}
+	for _, p := range pairs {
+		p := p
+		t.Run(p.stage, func(t *testing.T) {
+			t.Parallel()
+			ra, err := r.Render(p.stage, p.a)
+			if err != nil {
+				t.Fatalf("render A (%s): %v", p.stage, err)
+			}
+			rb, err := r.Render(p.stage, p.b)
+			if err != nil {
+				t.Fatalf("render B (%s): %v", p.stage, err)
+			}
+			prefixA := extractStablePrefix(t, ra)
+			prefixB := extractStablePrefix(t, rb)
+			if prefixA != prefixB {
+				t.Fatalf("%s prefix differs across two distinct stories — cache invariance broken\n--- A ---\n%s\n--- B ---\n%s",
+					p.stage, prefixA, prefixB)
+			}
+		})
+	}
+}
+
+// Cache invariance must hold across mode changes for stages that don't
+// vary protocol by mode (everything except code-review which has separate
+// strict/pragmatic protocol blocks — but those BOTH live in the prefix,
+// so a mode flip still keeps the prefix byte-identical).
+func TestRender_CacheInvariance_ModeFlip_PrefixStable(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	common := func(mode string) map[string]any {
+		return map[string]any{
+			"StoryID":      "1.1",
+			"HydratedFile": "/p/1.1.md",
+			"Mode":         mode,
+			"EnvConfig":    map[string]any{"PgPort": 7611, "DbName": "story_x"},
+		}
+	}
+	for _, stage := range []string{"stage_implement", "stage_code_review"} {
+		stage := stage
+		t.Run(stage, func(t *testing.T) {
+			t.Parallel()
+			dataA := common("pragmatic")
+			dataB := common("strict")
+			if stage == "stage_code_review" {
+				dataA["Iteration"] = 1
+				dataA["MaxIterations"] = 3
+				dataB["Iteration"] = 1
+				dataB["MaxIterations"] = 3
+			}
+			ra, err := r.Render(stage, dataA)
+			if err != nil {
+				t.Fatalf("render pragmatic: %v", err)
+			}
+			rb, err := r.Render(stage, dataB)
+			if err != nil {
+				t.Fatalf("render strict: %v", err)
+			}
+			if extractStablePrefix(t, ra) != extractStablePrefix(t, rb) {
+				t.Fatalf("%s: prefix changed when only mode flipped — protocol blocks must both live in the prefix",
+					stage)
+			}
+		})
+	}
+}
+
+// PriorAttempt is variable per dispatch (attempt number, prior reason) —
+// it MUST live in the suffix, not the prefix. A retry of the same story
+// should still re-use the prefix from the first attempt.
+func TestRender_CacheInvariance_PriorAttempt_DoesNotBustPrefix(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	base := map[string]any{
+		"StoryID":      "1.1",
+		"HydratedFile": "/p/1.1.md",
+		"Mode":         "pragmatic",
+		"EnvConfig":    map[string]any{"PgPort": 7611, "DbName": "story_x"},
+	}
+	withRetry := map[string]any{
+		"StoryID":      "1.1",
+		"HydratedFile": "/p/1.1.md",
+		"Mode":         "pragmatic",
+		"EnvConfig":    map[string]any{"PgPort": 7611, "DbName": "story_x"},
+		"PriorAttempt": map[string]any{
+			"AttemptNo": 2, "PrevStatus": "blocked", "PrevReason": "tests failed", "ConcernsCount": 1,
+		},
+	}
+	a, err := r.Render("stage_implement", base)
+	if err != nil {
+		t.Fatalf("render base: %v", err)
+	}
+	b, err := r.Render("stage_implement", withRetry)
+	if err != nil {
+		t.Fatalf("render retry: %v", err)
+	}
+	if extractStablePrefix(t, a) != extractStablePrefix(t, b) {
+		t.Fatalf("prefix changed when PriorAttempt was added — retry context must live in suffix")
 	}
 }

--- a/infrastructure/prompts/templates/stage_atdd.tmpl
+++ b/infrastructure/prompts/templates/stage_atdd.tmpl
@@ -6,17 +6,56 @@
                                     when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
+
+   Layout: stable PREFIX (protocol + return JSON) first, story-specific
+   SUFFIX last. Lets prompt cache anchor on the prefix (issue #20).
 */}}
-# Write Acceptance Tests for Story {{.StoryID}}
+# Write Acceptance Tests (stage: atdd)
 
 You are the **atdd-writer** L3 agent (STRICT mode). Per your agent
-definition, generate failing acceptance tests for this story BEFORE
+definition, generate failing acceptance tests for a story BEFORE
 implementation. Red-phase TDD.
 
-Hydrated spec: `{{.HydratedFile}}`
+The per-story details are appended at the end of this prompt under
+"## Story dispatch" — read that LAST.
 
+## Protocol — what to do (every atdd dispatch follows this)
+
+Read the hydrated spec referenced in the dispatch block. Translate each
+`Given/When/Then` acceptance criterion into a failing test. Tests must:
+- Compile cleanly
+- Fail for the right reason (assert against unimplemented behavior)
+- Be runnable via `go test ./...` (or repo-equivalent)
+
+If the story's ACs are purely doc/verification (e.g., "the choice is
+documented in X"), surface that and emit `status: blocked` with a clear
+reason — the orchestrator will route accordingly. STRICT mode forces
+this stage; the agent decides if it applies.
+
+## Return JSON shape (every atdd dispatch returns this shape)
+
+```json
+{
+  "story_id": "<echo from dispatch>",
+  "stage": "atdd",
+  "status": "ok|blocked|errored",
+  "reason": "...",
+  "tests_added": ["path/to/foo_test.go", "..."],
+  "idempotency_key": "<echo from dispatch if provided>"
+}
+```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
 {{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
-## Test environment (already up)
+### Test environment (already up)
 
 {{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
@@ -30,33 +69,7 @@ Hydrated spec: `{{.HydratedFile}}`
 {{end}}
 
 {{if .PriorAttempt -}}
-## Prior attempt summary
+### Prior attempt summary
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
-
-## What to do
-
-Read the hydrated spec. Translate each `Given/When/Then` acceptance
-criterion into a failing test. Tests must:
-- Compile cleanly
-- Fail for the right reason (assert against unimplemented behavior)
-- Be runnable via `go test ./...` (or repo-equivalent)
-
-If the story's ACs are purely doc/verification (e.g., "the choice is
-documented in X"), surface that and emit `status: blocked` with a clear
-reason — the orchestrator will route accordingly. STRICT mode forces
-this stage; the agent decides if it applies.
-
-## Return JSON
-
-```json
-{
-  "story_id": "{{.StoryID}}",
-  "stage": "atdd",
-  "status": "ok|blocked|errored",
-  "reason": "...",
-  "tests_added": ["path/to/foo_test.go", "..."]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
-}
-```

--- a/infrastructure/prompts/templates/stage_automate.tmpl
+++ b/infrastructure/prompts/templates/stage_automate.tmpl
@@ -6,18 +6,54 @@
                                     when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
+
+   Layout: stable PREFIX (protocol + return JSON) first, story-specific
+   SUFFIX last. Lets prompt cache anchor on the prefix (issue #20).
 */}}
-# Expand Test Coverage for Story {{.StoryID}}
+# Expand Test Coverage (stage: automate)
 
 You are the **test-automate** L3 agent (STRICT mode). The
-implementation has landed; ATDD covered acceptance-level. Your job
-per your agent definition: expand to unit + integration + contract
-coverage that ATDD's high-level focus missed.
+implementation has landed; ATDD covered acceptance-level. Your job per
+your agent definition: expand to unit + integration + contract coverage
+that ATDD's high-level focus missed.
 
-Hydrated spec: `{{.HydratedFile}}`
+The per-story details are appended at the end of this prompt under
+"## Story dispatch" — read that LAST.
 
+## Protocol — what to do (every automate dispatch follows this)
+
+Discover coverage gaps in the just-implemented work. Add tests at the
+level the original ATDD didn't cover (typically unit tests for branching
+logic, integration tests for adapter contracts). Tests must pass.
+
+If the implementation is purely doc/config (no code paths to cover),
+surface that and emit `status: blocked` with reason — the orchestrator
+will route accordingly.
+
+## Return JSON shape (every automate dispatch returns this shape)
+
+```json
+{
+  "story_id": "<echo from dispatch>",
+  "stage": "automate",
+  "status": "ok|blocked|errored",
+  "reason": "...",
+  "tests_added": ["..."],
+  "idempotency_key": "<echo from dispatch if provided>"
+}
+```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
 {{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
-## Test environment (already up)
+### Test environment (already up)
 
 {{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
@@ -31,30 +67,7 @@ Hydrated spec: `{{.HydratedFile}}`
 {{end}}
 
 {{if .PriorAttempt -}}
-## Prior attempt summary
+### Prior attempt summary
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
-
-## What to do
-
-Discover coverage gaps in the just-implemented work. Add tests at the
-level the original ATDD didn't cover (typically unit tests for branching
-logic, integration tests for adapter contracts). Tests must pass.
-
-If the implementation is purely doc/config (no code paths to cover),
-surface that and emit `status: blocked` with reason — the orchestrator
-will route accordingly.
-
-## Return JSON
-
-```json
-{
-  "story_id": "{{.StoryID}}",
-  "stage": "automate",
-  "status": "ok|blocked|errored",
-  "reason": "...",
-  "tests_added": ["..."]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
-}
-```

--- a/infrastructure/prompts/templates/stage_code_review.tmpl
+++ b/infrastructure/prompts/templates/stage_code_review.tmpl
@@ -8,54 +8,80 @@
        .MaxIterations   (int)      required — max_review_iterations from config
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
+
+   Layout: stable PREFIX (protocol + return JSON, including the per-mode
+   protocol block — mode is one of two known values so all rendered modes
+   share an identical structure aside from iteration counts) first; the
+   per-story SUFFIX last. Note: Iteration / MaxIterations live in the
+   suffix because they vary per dispatch even when mode is held constant.
+   Lets prompt cache anchor on the prefix (issue #20).
 */}}
-# Code Review for Story {{.StoryID}} (iteration {{.Iteration}} of {{.MaxIterations}})
+# Code Review (stage: code-review)
 
 You are the **code-reviewer** L3 agent. Adversarial review of source
-code (not tests — test-reviewer handles those) per your agent definition.
+code (not tests — test-reviewer handles those) per your agent
+definition.
 
-Hydrated spec: `{{.HydratedFile}}`
-Mode: **{{.Mode}}**
-{{if eq .Mode "strict" -}}
-STRICT: iterate till clean (this is iteration {{.Iteration}} of {{.MaxIterations}}).
-On blocking findings, the orchestrator dispatches tdd-implementer to
-address them, then re-dispatches you. After {{.MaxIterations}} iterations
-without convergence → story marked blocked.
-{{- else -}}
-PRAGMATIC: 1 round + advisory findings. Surface issues; do NOT block
-unless they're show-stoppers.
-{{- end}}
+The per-story details (including iteration counter and mode) are
+appended at the end of this prompt under "## Story dispatch" — read
+that LAST.
 
+## Protocol — strict mode
+
+When the dispatch block reports `Mode: strict`:
+
+- Iterate till clean (up to the iteration limit shown in the dispatch).
+- On blocking findings, the orchestrator dispatches tdd-implementer to
+  address them, then re-dispatches you.
+- After MaxIterations without convergence → story marked blocked.
+
+## Protocol — pragmatic mode
+
+When the dispatch block reports `Mode: pragmatic`:
+
+- 1 round + advisory findings.
+- Surface issues; do NOT block unless they're show-stoppers.
+
+## Protocol — what to do
+
+Review the source code changes (NOT tests) per your agent definition. On
+blocking findings (strict) or any findings (pragmatic), emit
+`status: blocked` with a precise list. Otherwise `status: ok`.
+
+## Return JSON shape (every code-review dispatch returns this shape)
+
+```json
+{
+  "story_id": "<echo from dispatch>",
+  "stage": "code-review",
+  "iteration": <echo from dispatch>,
+  "status": "ok|blocked|errored",
+  "reason": "...",
+  "findings": [
+    {"severity": "blocking|advisory", "file": "path", "line": 0, "note": "..."}
+  ],
+  "idempotency_key": "<echo from dispatch if provided>"
+}
+```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+- Iteration: **{{.Iteration}} of {{.MaxIterations}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
 {{if .EnvConfig.PgPort -}}
-## Test environment
+### Test environment
 
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
 {{end}}
 
 {{if .PriorAttempt -}}
-## Prior attempt summary
+### Prior attempt summary
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
-
-## What to do
-
-Review the source code changes (NOT tests) per your agent definition.
-On {{if eq .Mode "strict"}}blocking{{else}}any{{end}} findings, emit
-`status: blocked` with a precise list. Otherwise `status: ok`.
-
-## Return JSON
-
-```json
-{
-  "story_id": "{{.StoryID}}",
-  "stage": "code-review",
-  "iteration": {{.Iteration}},
-  "status": "ok|blocked|errored",
-  "reason": "...",
-  "findings": [
-    {"severity": "blocking|advisory", "file": "path", "line": 0, "note": "..."}
-  ]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
-}
-```

--- a/infrastructure/prompts/templates/stage_commit.tmpl
+++ b/infrastructure/prompts/templates/stage_commit.tmpl
@@ -5,19 +5,56 @@
        .Branch          (string)   required — git branch the worktree is on
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
-*/}}
-# Commit Story {{.StoryID}}
 
-Commit + push the work for this story. Use the `smart-commit` skill
+   Layout: stable PREFIX (protocol + return JSON) first, story-specific
+   SUFFIX (branch + paths + retries) last. Lets prompt cache anchor on
+   the prefix (issue #20).
+*/}}
+# Commit (stage: commit)
+
+Commit + push the work for a story. Use the `smart-commit` skill
 (installed at ~/.claude/skills/smart-commit/) to categorize the diff,
 choose modular-vs-single commit, and produce a conventional message.
 
-Branch: `{{.Branch}}`
-Hydrated spec: `{{.HydratedFile}}`
-Mode: **{{.Mode}}**
+The per-story details (branch, hydrated spec, mode) are appended at the
+end of this prompt under "## Story dispatch" — read that LAST.
 
+## Protocol — what to do (every commit dispatch follows this)
+
+1. Invoke the smart-commit skill against the staged + unstaged diff
+   in the worktree on the branch shown in the dispatch block.
+2. After commit lands, run `task check` (or repo-equivalent) to
+   verify CI green.
+3. If CI fails → `status: blocked` with the failing target's output.
+4. If CI passes → push the branch; ready for PR.
+
+## Return JSON shape (every commit dispatch returns this shape)
+
+```json
+{
+  "story_id": "<echo from dispatch>",
+  "stage": "commit",
+  "status": "ok|blocked|errored",
+  "reason": "...",
+  "commit_hash": "...",
+  "branch": "<echo from dispatch>",
+  "ci_passed": true,
+  "idempotency_key": "<echo from dispatch if provided>"
+}
+```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Branch: `{{.Branch}}`
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
 {{if .PriorAttempt -}}
-## Prior attempt summary
+### Prior attempt summary
 
 {{template "retry_context" .PriorAttempt}}
 
@@ -25,27 +62,3 @@ The prior commit attempt failed CI (`task check`). The blocker(s) live
 in the previous attempt's `reason`. Fix them with a follow-up commit
 (re-run TDD as needed), then re-attempt this commit stage.
 {{- end}}
-
-## What to do
-
-1. Invoke the smart-commit skill against the staged + unstaged diff
-   in the worktree on branch `{{.Branch}}`.
-2. After commit lands, run `task check` (or repo-equivalent) to
-   verify CI green.
-3. If CI fails → `status: blocked` with the failing target's output.
-4. If CI passes → push the branch; ready for PR.
-
-## Return JSON
-
-```json
-{
-  "story_id": "{{.StoryID}}",
-  "stage": "commit",
-  "status": "ok|blocked|errored",
-  "reason": "...",
-  "commit_hash": "...",
-  "branch": "{{.Branch}}",
-  "ci_passed": true{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
-}
-```

--- a/infrastructure/prompts/templates/stage_hydrate.tmpl
+++ b/infrastructure/prompts/templates/stage_hydrate.tmpl
@@ -16,59 +16,22 @@
                                            bundle isn't enough.
        .PriorAttempt            (*struct)  optional
        .IdempotencyKey          (string)   optional
+
+   Layout: stable PREFIX (atlas guide + protocol + return JSON) first,
+   per-story SUFFIX last. The bundle-path conditionals live in the suffix
+   because they reference per-story bundle paths. Lets prompt cache
+   anchor on the prefix (issue #20).
 */}}
-# Hydrate Story {{.StoryID}}
+# Hydrate (stage: hydrate)
 
-You are the **story-hydrator** L3 agent. Take this lightweight story from
-`epics.md` and produce the full per-story implementation file at
-`{{.HydratedFile}}` per your agent definition's protocol.
+You are the **story-hydrator** L3 agent. Take a lightweight story from
+`epics.md` and produce the full per-story implementation file at the
+hydrated path appended in the dispatch block — per your agent
+definition's protocol.
 
-Mode: **{{.Mode}}**
-
-{{if .StoryContextBundlePath -}}
-## Per-story curated context (read this FIRST — pre-extracted)
-
-`{{.StoryContextBundlePath}}` is a deterministic extract just for this
-story: the lightweight epics.md entry + the architecture sections
-matching every `FR-*` reference in that entry. Reading this one file
-covers ~95% of what the hydrator needs — saves the agent from grepping
-architecture.md / audit / saga-mapping at runtime.
-
-**Read this file as your PRIMARY context.** Only fall back to the
-sources below if a section you need is missing from the bundle (the
-bundle's warnings list flags any FR ref the extractor couldn't match).
-
-{{else if .CacheBundlePath -}}
-## Standing corpus (read this ONCE — pre-bundled)
-
-`{{.CacheBundlePath}}` contains the architecture canon + BC audit (+
-supplement) + EDA cutover decision tree + saga-to-slice mapping
-concatenated with anchor headings. Read it FIRST and rely on the
-contents for cross-cutting context — do NOT re-read the individual
-source files unless you need a section the bundle missed.
-
-## Per-story inputs (always read fresh)
-
-- Lightweight story: in `{{.EpicsPath}}` under `### Story {{.StoryID}}:`
-
-{{- else -}}
-## Source inputs (fallback — no bundle configured)
-
-- Lightweight story: in `{{.EpicsPath}}` under `### Story {{.StoryID}}:`
-- Architecture canon: `{{.ArchitecturePath}}`
-- Companion artifacts (BC audit, saga mapping, Pattern Applicability Matrix):
-  in the same `docs/architecture/eda-cutover/` directory
-
-Tip: run `bmad story context-bundle {{.StoryID}}` for a per-story
-curated bundle (highest leverage), or `bmad sprint cache-bundle`
-for a sprint-wide standing corpus.
-{{- end}}
-
-{{if .PriorAttempt -}}
-## Prior attempt summary
-
-{{template "retry_context" .PriorAttempt}}
-{{- end}}
+The per-story details (story id, epics path, hydrated output path, mode,
+bundle paths) are appended at the end of this prompt under "## Story
+dispatch" — read that LAST.
 
 ## Codebase discovery — prefer atlas CLI over grep
 
@@ -96,23 +59,85 @@ full verb listing. The atlas state DB is at `.atlas/atlas.db`
 — use `atlas codebase find` to resolve a feature ID's primary symbol
 first.
 
-## What to do
+## Protocol — what to do (every hydrate dispatch follows this)
 
 Follow your agent definition's hydration protocol. Write the hydrated
-file to `{{.HydratedFile}}` and DO NOT modify any other file.
+file to the path shown in the dispatch block and DO NOT modify any
+other file.
 
-## Return JSON
+If the dispatch block lists a per-story context bundle, **read that file
+FIRST as your primary context** — it's a deterministic extract of the
+lightweight epics entry plus the architecture sections matching every
+`FR-*` ref in the entry, covering ~95% of what the hydrator needs.
+Only fall back to the source files (epics, architecture canon, BC
+audit) if a section you need is missing from the bundle (the bundle's
+warnings list flags any unresolved FR ref).
+
+If no per-story bundle but a sprint-wide cache bundle is provided,
+read it ONCE and rely on it for cross-cutting context — do NOT re-read
+the individual source files unless a section is missing.
+
+If neither bundle is provided, fall back to reading the raw sources
+referenced in the dispatch block.
+
+## Return JSON shape (every hydrate dispatch returns this shape)
 
 ```json
 {
-  "story_id": "{{.StoryID}}",
+  "story_id": "<echo from dispatch>",
   "stage": "hydrate",
   "status": "ok|blocked|errored",
   "reason": "...",
-  "hydrated_file_path": "{{.HydratedFile}}",
+  "hydrated_file_path": "<echo from dispatch>",
   "slice": "...",
   "bc_target": "...",
-  "fr_refs": ["..."]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
+  "fr_refs": ["..."],
+  "idempotency_key": "<echo from dispatch if provided>"
 }
 ```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Mode: **{{.Mode}}**
+- Hydrated output path: `{{.HydratedFile}}`
+- Lightweight story: in `{{.EpicsPath}}` under `### Story {{.StoryID}}:`
+- Architecture canon: `{{.ArchitecturePath}}`
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
+{{if .StoryContextBundlePath -}}
+### Per-story curated context (PRIMARY — read FIRST)
+
+`{{.StoryContextBundlePath}}` — pre-extracted, just for this story.
+Covers ~95% of what hydration needs. The bundle's warnings list flags
+any FR ref the extractor couldn't match.
+{{- end}}
+
+{{if and (not .StoryContextBundlePath) .CacheBundlePath -}}
+### Standing corpus (read ONCE — pre-bundled)
+
+`{{.CacheBundlePath}}` — architecture canon + BC audit + EDA cutover
+decision tree + saga-to-slice mapping, concatenated with anchor
+headings. Rely on its contents for cross-cutting context; do NOT
+re-read the individual source files unless a section is missing.
+{{- end}}
+
+{{if and (not .StoryContextBundlePath) (not .CacheBundlePath) -}}
+### Source inputs (fallback — no bundle configured)
+
+- Companion artifacts (BC audit, saga mapping, Pattern Applicability
+  Matrix): in the same `docs/architecture/eda-cutover/` directory as
+  the architecture canon listed above.
+
+Tip: run `bmad story context-bundle {{.StoryID}}` for a per-story
+curated bundle (highest leverage), or `bmad sprint cache-bundle` for a
+sprint-wide standing corpus.
+{{- end}}
+
+{{if .PriorAttempt -}}
+### Prior attempt summary
+
+{{template "retry_context" .PriorAttempt}}
+{{- end}}

--- a/infrastructure/prompts/templates/stage_implement.tmpl
+++ b/infrastructure/prompts/templates/stage_implement.tmpl
@@ -13,46 +13,17 @@
        .PriorAttempt            (*struct)  optional — populated on retries
        .EpicContext             (string)   optional — excerpt of epic file
        .IdempotencyKey          (string)   optional — agent MUST echo back in return JSON
+
+   Layout: cache-stable PREFIX first (atlas guide + protocol + JSON schema —
+   byte-identical across every dispatch of this stage), then variable per-story
+   data appended as a SUFFIX. This ordering lets Anthropic prompt-cache anchor
+   on the prefix and only re-encode the suffix per dispatch (issue #20).
 */}}
-# Implement Story {{.StoryID}}
+# Implement (stage: implement)
 
-Hydrated spec: `{{.HydratedFile}}`
-Mode: **{{.Mode}}**
-
-{{if .StoryContextBundlePath -}}
-## Per-story curated context
-
-`{{.StoryContextBundlePath}}` — pre-extracted lightweight epics entry +
-matching architecture sections for this story's FR refs. The hydrator
-already consumed this file; if you need quick reminders of the spec's
-"why" without re-reading the full hydrated file, skim here.
-{{- end}}
-
-{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
-## Test environment (already up — do NOT recreate)
-
-{{if .EnvConfig.PgPort -}}
-- PostgreSQL on `:{{.EnvConfig.PgPort}}`  (db: `{{.EnvConfig.DbName}}`)
-{{end -}}
-{{if .EnvConfig.RedisPort -}}
-- Redis on `:{{.EnvConfig.RedisPort}}`
-{{end -}}
-{{if .EnvConfig.OtelPort -}}
-- OTEL on `:{{.EnvConfig.OtelPort}}`
-{{end -}}
-{{end}}
-
-{{if .PriorAttempt -}}
-## Prior attempt summary
-
-{{template "retry_context" .PriorAttempt}}
-{{- end}}
-
-{{if .EpicContext -}}
-## Epic context
-
-{{.EpicContext}}
-{{- end}}
+You are the **tdd-implementer** L3 agent. The per-story spec is appended at
+the end of this prompt under "## Story dispatch" — read that LAST, after the
+protocol below is in working memory.
 
 ## Codebase discovery — prefer atlas CLI over grep
 
@@ -80,22 +51,69 @@ full verb listing. The atlas state DB is at `.atlas/atlas.db`
 — use `atlas codebase find` to resolve a feature ID's primary symbol
 first.
 
-## What to do
+## Protocol — what to do (every implement dispatch follows this)
 
-1. Read the hydrated spec at `{{.HydratedFile}}`.
+1. Read the hydrated spec at the path appended in "## Story dispatch" below.
 2. Run TDD per the spec's checklist (red → green → refactor).
 3. Run `task check` (or repo-equivalent) before signaling completion.
-4. Emit JSON result. {{if .IdempotencyKey}}You MUST include `"idempotency_key"` as
-   shown below so the orchestrator can close out the right dispatch row.{{end}}
+4. Emit JSON result. When an idempotency key is appended in the dispatch
+   block, you MUST include `"idempotency_key"` in your return so the
+   orchestrator can close out the right dispatch row.
+
+## Return JSON shape (every implement dispatch returns this shape)
 
 ```json
 {
-  "story_id": "{{.StoryID}}",
+  "story_id": "<echo from dispatch>",
   "stage": "implement",
   "status": "ok|blocked|errored",
   "reason": "...",
   "files_changed": ["..."],
-  "tests_added": ["..."]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
+  "tests_added": ["..."],
+  "idempotency_key": "<echo from dispatch if provided>"
 }
 ```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
+{{if .StoryContextBundlePath -}}
+### Per-story curated context
+
+`{{.StoryContextBundlePath}}` — pre-extracted lightweight epics entry +
+matching architecture sections for this story's FR refs. The hydrator
+already consumed this file; if you need quick reminders of the spec's
+"why" without re-reading the full hydrated file, skim here.
+{{- end}}
+
+{{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
+### Test environment (already up — do NOT recreate)
+
+{{if .EnvConfig.PgPort -}}
+- PostgreSQL on `:{{.EnvConfig.PgPort}}`  (db: `{{.EnvConfig.DbName}}`)
+{{end -}}
+{{if .EnvConfig.RedisPort -}}
+- Redis on `:{{.EnvConfig.RedisPort}}`
+{{end -}}
+{{if .EnvConfig.OtelPort -}}
+- OTEL on `:{{.EnvConfig.OtelPort}}`
+{{end -}}
+{{end}}
+
+{{if .PriorAttempt -}}
+### Prior attempt summary
+
+{{template "retry_context" .PriorAttempt}}
+{{- end}}
+
+{{if .EpicContext -}}
+### Epic context
+
+{{.EpicContext}}
+{{- end}}

--- a/infrastructure/prompts/templates/stage_test_review.tmpl
+++ b/infrastructure/prompts/templates/stage_test_review.tmpl
@@ -6,18 +6,56 @@
                                     when no port is set (issue #17)
        .PriorAttempt    (*struct)  optional
        .IdempotencyKey  (string)   optional
-*/}}
-# Review Tests for Story {{.StoryID}}
 
-You are the **test-reviewer** L3 agent (STRICT mode). Audit the test
-suite for this story on 8 quality dimensions per your agent definition:
+   Layout: stable PREFIX (protocol + return JSON) first, story-specific
+   SUFFIX last. Lets prompt cache anchor on the prefix (issue #20).
+*/}}
+# Review Tests (stage: test-review)
+
+You are the **test-reviewer** L3 agent (STRICT mode). Audit a story's
+test suite on 8 quality dimensions per your agent definition:
 determinism, isolation, maintainability, readability, performance,
 naming, coverage, anti-patterns. Score 0-100.
 
-Hydrated spec: `{{.HydratedFile}}`
+The per-story details are appended at the end of this prompt under
+"## Story dispatch" — read that LAST.
 
+## Protocol — what to do (every test-review dispatch follows this)
+
+Read the tests added by ATDD + test-automate for this story. Audit each
+dimension. If score < 80 OR any dimension has a blocking finding, emit
+`status: blocked` — the orchestrator will route back to test-automate
+or implement (per max_qa_cycles budget). Otherwise `status: ok`.
+
+## Return JSON shape (every test-review dispatch returns this shape)
+
+```json
+{
+  "story_id": "<echo from dispatch>",
+  "stage": "test-review",
+  "status": "ok|blocked|errored",
+  "reason": "...",
+  "scores": {
+    "determinism": 0, "isolation": 0, "maintainability": 0,
+    "readability": 0, "performance": 0, "naming": 0,
+    "coverage": 0, "anti_patterns": 0
+  },
+  "blocking_findings": ["..."],
+  "idempotency_key": "<echo from dispatch if provided>"
+}
+```
+
+{{/* ──────── Cache boundary — content above is byte-stable across dispatches ──────── */ -}}
+
+## Story dispatch
+
+- Story ID: **{{.StoryID}}**
+- Hydrated spec: `{{.HydratedFile}}`
+- Mode: **{{.Mode}}**
+{{if .IdempotencyKey}}- Idempotency key: `{{.IdempotencyKey}}` (echo this in your return JSON)
+{{end}}
 {{if or .EnvConfig.PgPort .EnvConfig.RedisPort .EnvConfig.OtelPort -}}
-## Test environment
+### Test environment
 
 {{if .EnvConfig.PgPort -}}
 - Postgres :{{.EnvConfig.PgPort}} (db: `{{.EnvConfig.DbName}}`)
@@ -31,32 +69,7 @@ Hydrated spec: `{{.HydratedFile}}`
 {{end}}
 
 {{if .PriorAttempt -}}
-## Prior attempt summary
+### Prior attempt summary
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
-
-## What to do
-
-Read the tests added by ATDD + test-automate for this story. Audit each
-dimension. If score < 80 OR any dimension has a blocking finding, emit
-`status: blocked` — the orchestrator will route back to test-automate
-or implement (per max_qa_cycles budget). Otherwise `status: ok`.
-
-## Return JSON
-
-```json
-{
-  "story_id": "{{.StoryID}}",
-  "stage": "test-review",
-  "status": "ok|blocked|errored",
-  "reason": "...",
-  "scores": {
-    "determinism": 0, "isolation": 0, "maintainability": 0,
-    "readability": 0, "performance": 0, "naming": 0,
-    "coverage": 0, "anti_patterns": 0
-  },
-  "blocking_findings": ["..."]{{if .IdempotencyKey}},
-  "idempotency_key": "{{.IdempotencyKey}}"{{end}}
-}
-```


### PR DESCRIPTION
## Summary

- Closes #20. Root-causes 0% `cache_hit_rate` across 1.25M input tokens of Epic 1 + Epic 2 batch 1 dispatches to **Hypothesis 1**: every `stage_*.tmpl` opens with `# <Action> Story {{.StoryID}}` and injects HydratedFile + Mode + EnvConfig in the first ~30 tokens, breaking Anthropic's prompt-cache prefix invariance on line 1.
- Restructures all 7 stage templates so cache-stable content (atlas guide, protocol, return-JSON schema, per-mode protocol blocks) is the PREFIX, and per-story slot data is the SUFFIX under a canonical `## Story dispatch` heading.
- Adds `bmad render --debug-cache-prefix` so operators can visually confirm where the boundary lives — wraps the prefix with `=== STABLE PREFIX ===` / `=== VARIABLE SUFFIX ===` markers anchored on a line-anchored `\n## Story dispatch\n` literal.

## Diagnosis

**Hypothesis 1 (PRIMARY ROOT CAUSE) — CONFIRMED.**
Inspection of every `stage_*.tmpl` showed cache-busting variables (`{{.StoryID}}`, `{{.HydratedFile}}`, `{{.Mode}}`, `{{.EnvConfig.*}}`) inside the first 30 tokens. Anthropic prompt cache requires byte-identical prefix; once StoryID changes between dispatches, the boundary fails immediately.

**Hypothesis 2 — secondary, addressed transitively.** The L1 orchestrator skill (verified at `.claude/skills/bmad-v6-orchestrator/SKILL.md`) already passes `bmad render`'s output verbatim to Task. With the prefix now genuinely stable, the L1's pass-verbatim behavior becomes cache-effective.

**Hypothesis 3 — not investigated further.** Claude Code subagent ephemeral-context injection MAY further fragment the cache, but Hypothesis 1's fix is sufficient to take cache_hit_rate from 0% → meaningful baseline. If hits stay 0% after this PR lands, Hypothesis 3 becomes actionable as a follow-up.

**Hypothesis 4 — REJECTED.** Skill `f338b653` explicitly mandates parsing all four `<usage>` fields; the 0% is real data, not a parsing bug.

## Technical changes

**Template restructure (`infrastructure/prompts/templates/stage_*.tmpl`)**

Every stage template now follows this layout:
```
# <Stable stage heading — no variables>
You are the <role> L3 agent. The per-story spec is appended at the end of
this prompt under "## Story dispatch" — read that LAST.

<atlas guide if applicable — stable>
<protocol — stable>
<return-JSON schema with `<echo from dispatch>` placeholders — stable>

[cache boundary]

## Story dispatch
- Story ID: **<id>**
- Hydrated spec: `<path>`
- Mode: **<mode>**
- Idempotency key: `<key>`
<EnvConfig block if any port set>
<PriorAttempt block if retry>
```

For `stage_code_review`, the per-mode (strict vs pragmatic) protocol blocks BOTH live in the prefix. The variable `Iteration / MaxIterations` counter lives in the suffix.

**`cmd/render.go` — new `--debug-cache-prefix` flag**

Emits the rendered prompt with explicit boundary markers:
```
=== STABLE PREFIX (cache-eligible — byte-identical across dispatches of this stage) ===
...
=== VARIABLE SUFFIX (per-story — cache-busts here onward) ===
## Story dispatch
- Story ID: **1.1**
...
=== END ===
```
Boundary is anchored on `\n## Story dispatch\n` so prose mentions of the heading inside the prefix (e.g. "appended at the end of this prompt under '## Story dispatch'") don't false-match.

**`infrastructure/prompts/renderer_test.go` — invariance contract tests**

Three new test families lock in the contract:
1. `CacheInvariance_AllStages_PrefixStableAcrossStories` — for every stage template, two distinct stories → byte-identical prefix.
2. `CacheInvariance_ModeFlip_PrefixStable` — strict↔pragmatic flips don't bust prefix.
3. `CacheInvariance_PriorAttempt_DoesNotBustPrefix` — retry context stays in suffix.

## Smoke verification (manual)

```bash
# 2258-byte byte-identical prefix across two distinct stories
$ bmad render stage_implement --data-json '{"StoryID":"1.1",...}' > p1
$ bmad render stage_implement --data-json '{"StoryID":"9.9",...}' > p2
# stable prefix lengths: 2258 / 2258
# prefixes byte-identical: True
```

Live verification of cache_hit_rate uplift against nutrition Epic 2 dispatches happens after merge (the dev session will smoke-dispatch one stage type twice + capture the `<usage>` block; target: `cache_read_input_tokens > 0` on dispatch #2).

## Scope discipline

Per the dispatch instructions, this PR explicitly does NOT touch any file in Batch D's scope (`application/sprint/planner.go`, `cmd/dispatch.go`, `cmd/story.go`, `application/state/*`). All changes are confined to `cmd/render.go` and `infrastructure/prompts/`.

The one pre-existing test failure on v2 (`TestBuildStoryContext_NutritionV2Go_Story12_NoExistingFiles` in `application/sprint`) is brittle live-checkout-dependent code unrelated to this PR — verified by running on clean `v2` HEAD before applying any changes.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./infrastructure/prompts/...` — all green incl. 9 new cache-invariance tests
- [x] `go test -race ./cmd/...` — green
- [x] Manual smoke: `bmad render stage_implement --debug-cache-prefix` produces correct STABLE PREFIX / VARIABLE SUFFIX partition
- [x] Manual smoke: two distinct stories produce byte-identical 2258-byte prefix for `stage_implement`
- [ ] Post-merge: nutrition Epic 2 next dispatch shows `cache_read_input_tokens > 0` on the 2nd dispatch of the same stage type
- [ ] Post-merge: `bmad sprint status` shows `cache_hit_rate >= 20%` over next batch (was 0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)