### PR TITLE
feat: codeindex cache eviction + atlas dep bump (closes #12)

### DIFF
--- a/application/sprint/codecontext.go
+++ b/application/sprint/codecontext.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -24,6 +25,18 @@ import (
 // Existing dispatches that already have a bundle on disk are not affected by
 // the flag at read-time — only bundle BUILDS consult it.
 const EnvIncludeAtlas = "BMAD_CONTEXT_BUNDLE_INCLUDE_ATLAS"
+
+// EnvCacheMaxFiles overrides DefaultCacheMaxFiles for the per-directory cap on
+// retained codeindex cache files. Set to a positive integer to change the
+// budget; values <= 0 (or unparseable strings) fall back to the default.
+const EnvCacheMaxFiles = "BMAD_CACHE_MAX_FILES"
+
+// DefaultCacheMaxFiles caps how many <head>.json cache files we retain in any
+// single cache directory. After each write we count siblings and delete the
+// oldest-by-mtime until we're back at the cap. A ~10MB-per-file payload over
+// a typical N=5 budget keeps the directory under 50MB even on long-lived
+// checkouts that scan many HEADs.
+const DefaultCacheMaxFiles = 5
 
 // DefaultCodeContextMaxHops is the dependency-graph walk depth. 2 hops keeps
 // the output bounded (typical fanout per symbol is 3-5) while still surfacing
@@ -251,6 +264,81 @@ func writeCachedIndex(path string, idx *codeindex.Index, logger shared.Logger) {
 	if err := os.Rename(tmp, path); err != nil {
 		logger.Warn(context.Background(), "code context: cache rename",
 			"path", path, "err", err.Error())
+		return
+	}
+
+	evictOldCacheFiles(filepath.Dir(path), cacheMaxFiles(), logger)
+}
+
+// cacheMaxFiles returns the configured per-directory cap. BMAD_CACHE_MAX_FILES
+// overrides the default when set to a positive integer; otherwise the default
+// is used. We treat unparseable / non-positive values as "use the default" so
+// a typo never disables eviction silently.
+func cacheMaxFiles() int {
+	raw := strings.TrimSpace(os.Getenv(EnvCacheMaxFiles))
+	if raw == "" {
+		return DefaultCacheMaxFiles
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultCacheMaxFiles
+	}
+	return n
+}
+
+// evictOldCacheFiles enforces a per-directory cap on `*.json` cache files.
+// When the count exceeds `max`, the oldest-by-mtime entries are removed until
+// the count is back at `max`. Eviction failures are logged but never returned
+// — the cache write itself already succeeded by this point, and we don't want
+// a stuck file to fail the bundle build.
+//
+// Only files with a `.json` suffix are considered. Sub-directories, dot-files,
+// and the `<head>.json.tmp` rename-staging files are ignored.
+func evictOldCacheFiles(dir string, max int, logger shared.Logger) {
+	if max <= 0 {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		logger.Warn(context.Background(), "code context: cache evict readdir",
+			"dir", dir, "err", err.Error())
+		return
+	}
+	type cachedFile struct {
+		path  string
+		mtime int64
+	}
+	files := make([]cachedFile, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, cachedFile{
+			path:  filepath.Join(dir, name),
+			mtime: info.ModTime().UnixNano(),
+		})
+	}
+	if len(files) <= max {
+		return
+	}
+	// Sort oldest-first (ascending mtime).
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].mtime < files[j].mtime
+	})
+	toEvict := len(files) - max
+	for i := 0; i < toEvict; i++ {
+		if err := os.Remove(files[i].path); err != nil {
+			logger.Warn(context.Background(), "code context: cache evict",
+				"path", files[i].path, "err", err.Error())
+		}
 	}
 }
 

--- a/application/sprint/eviction_test.go
+++ b/application/sprint/eviction_test.go
@@ -1,0 +1,180 @@
+package sprint
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/sosalejandro/atlas/packages/shared"
+)
+
+// TestEvictOldCacheFiles_KeepsNewestRemovesOldest writes 6 fake cache files
+// with staggered mtimes and asserts the eviction policy keeps the 5 newest
+// (the issue #12 default budget) and removes the single oldest by mtime.
+//
+// We exercise the helper directly (white-box internal test) rather than
+// routing through BuildCodeContextSection, which would require running the
+// real atlas scanner against a synthetic source tree.
+func TestEvictOldCacheFiles_KeepsNewestRemovesOldest(t *testing.T) {
+	dir := t.TempDir()
+
+	// Six files, oldest first. We pin each file's mtime explicitly so the
+	// test isn't subject to FS-timestamp granularity races.
+	base := time.Now().Add(-6 * time.Hour)
+	heads := []string{
+		"aaaaaa1", "bbbbbb2", "cccccc3",
+		"dddddd4", "eeeeee5", "ffffff6",
+	}
+	for i, h := range heads {
+		p := filepath.Join(dir, h+".json")
+		if err := os.WriteFile(p, []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("seed write %s: %v", h, err)
+		}
+		mt := base.Add(time.Duration(i) * time.Hour)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes %s: %v", h, err)
+		}
+	}
+
+	evictOldCacheFiles(dir, 5, shared.NopLogger{})
+
+	got, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var names []string
+	for _, e := range got {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	// Oldest (heads[0] = "aaaaaa1") must be gone; the remaining 5 must
+	// match heads[1:] exactly.
+	want := []string{
+		"bbbbbb2.json", "cccccc3.json", "dddddd4.json",
+		"eeeeee5.json", "ffffff6.json",
+	}
+	if len(names) != len(want) {
+		t.Fatalf("expected %d files post-eviction, got %d: %v",
+			len(want), len(names), names)
+	}
+	for i, n := range names {
+		if n != want[i] {
+			t.Errorf("file[%d] = %q, want %q (full list: %v)",
+				i, n, want[i], names)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "aaaaaa1.json")); !os.IsNotExist(err) {
+		t.Errorf("oldest file aaaaaa1.json should be removed, stat err = %v", err)
+	}
+}
+
+// TestEvictOldCacheFiles_NoOpWhenUnderCap verifies the helper makes no FS
+// changes when sibling count is at or below the cap.
+func TestEvictOldCacheFiles_NoOpWhenUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	for _, h := range []string{"h1.json", "h2.json", "h3.json"} {
+		if err := os.WriteFile(filepath.Join(dir, h), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	evictOldCacheFiles(dir, 5, shared.NopLogger{})
+
+	got, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 files (under cap → no-op), got %d", len(got))
+	}
+}
+
+// TestEvictOldCacheFiles_IgnoresNonJSON ensures stray .tmp / dot-files and
+// sub-directories aren't counted toward the budget and aren't removed.
+func TestEvictOldCacheFiles_IgnoresNonJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	// 5 .json files (at the cap) plus a .tmp staging file and a subdir.
+	// Eviction must touch none of them.
+	for _, h := range []string{"a.json", "b.json", "c.json", "d.json", "e.json"} {
+		if err := os.WriteFile(filepath.Join(dir, h), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("seed json: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "current.json.tmp"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed tmp: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("seed subdir: %v", err)
+	}
+
+	evictOldCacheFiles(dir, 5, shared.NopLogger{})
+
+	if _, err := os.Stat(filepath.Join(dir, "current.json.tmp")); err != nil {
+		t.Errorf(".tmp staging file removed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subdir")); err != nil {
+		t.Errorf("subdir removed unexpectedly: %v", err)
+	}
+}
+
+// TestCacheMaxFiles_EnvOverride verifies BMAD_CACHE_MAX_FILES parses
+// positive integers and falls back to the default for invalid input.
+func TestCacheMaxFiles_EnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset_default", "", DefaultCacheMaxFiles},
+		{"valid_3", "3", 3},
+		{"valid_10", "10", 10},
+		{"zero_default", "0", DefaultCacheMaxFiles},
+		{"negative_default", "-2", DefaultCacheMaxFiles},
+		{"garbage_default", "abc", DefaultCacheMaxFiles},
+		{"whitespace_padded", "  4  ", 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvCacheMaxFiles, tc.env)
+			if got := cacheMaxFiles(); got != tc.want {
+				t.Errorf("cacheMaxFiles() = %d, want %d (env=%q)", got, tc.want, tc.env)
+			}
+		})
+	}
+}
+
+// TestEvictOldCacheFiles_HonorsCustomCap exercises a non-default cap (2) to
+// guard the parameterization — the live path reads it from the env var, but
+// the helper itself must obey whatever value it's handed.
+func TestEvictOldCacheFiles_HonorsCustomCap(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now().Add(-10 * time.Hour)
+	for i, h := range []string{"o1", "o2", "o3", "o4"} {
+		p := filepath.Join(dir, h+".json")
+		if err := os.WriteFile(p, []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		mt := base.Add(time.Duration(i) * time.Hour)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+	evictOldCacheFiles(dir, 2, shared.NopLogger{})
+
+	got, _ := os.ReadDir(dir)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 files after cap=2 eviction, got %d", len(got))
+	}
+	// Newest two are o3 and o4.
+	have := map[string]bool{}
+	for _, e := range got {
+		have[e.Name()] = true
+	}
+	if !have["o3.json"] || !have["o4.json"] {
+		t.Errorf("expected o3.json + o4.json to survive, got %v", have)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sosalejandro/bmad-story-runner-cli
 go 1.25.7
 
 require (
-	github.com/sosalejandro/atlas v0.0.0-20260518085730-ae2e4e1b51d2
+	github.com/sosalejandro/atlas v0.1.2
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sosalejandro/atlas v0.0.0-20260518085730-ae2e4e1b51d2 h1:P8CU7N2zAf/sXjfgp2IIJLe6f9PrMRsow6WZ0Yovm5M=
-github.com/sosalejandro/atlas v0.0.0-20260518085730-ae2e4e1b51d2/go.mod h1:VFA+f1picf8asZGkVKhKFwHvy05Xeg+U5QjVca40+jE=
+github.com/sosalejandro/atlas v0.1.2 h1:9Y15BD6pXwewFkgC7rbfmhXKaZBJrYg4+d3IPtyjyvc=
+github.com/sosalejandro/atlas v0.1.2/go.mod h1:VFA+f1picf8asZGkVKhKFwHvy05Xeg+U5QjVca40+jE=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
## Summary

Closes both parts of #12 in two atomic commits.

### Part (b) — codeindex cache eviction (commit `00b2ca5`)

Phase 10 (PR #11) writes ~10MB JSON snapshots of the atlas codeindex to `<repo>/_bmad-output/.codeindex-cache/<head>.json`, keyed by git HEAD. The cache was previously unbounded — every distinct HEAD scanned during the life of a checkout produced another retained file. Long-lived checkouts could accumulate gigabytes.

**Eviction policy** (in `application/sprint/codecontext.go`):
- After each successful cache write, count sibling `*.json` files.
- If count > cap, remove oldest-by-mtime until count == cap.
- Default cap = **5** (~50MB ceiling per cache dir).
- Cap overridable via `BMAD_CACHE_MAX_FILES`; non-positive / unparseable values fall back to default.
- Eviction failures are logged (NopLogger-safe) but never returned — the cache write itself already succeeded.
- Non-`.json` entries (`*.json.tmp` staging files, sub-directories, dot-files) are ignored — only `<head>.json` snapshots count toward the budget.

**Unit tests** (`application/sprint/eviction_test.go`, white-box `package sprint`):
- `TestEvictOldCacheFiles_KeepsNewestRemovesOldest` — 6 files with `os.Chtimes`-pinned mtimes, asserts the oldest is removed + the newest 5 survive.
- `TestEvictOldCacheFiles_NoOpWhenUnderCap` — count ≤ cap is a no-op.
- `TestEvictOldCacheFiles_IgnoresNonJSON` — `.tmp` files and subdirs are not touched.
- `TestEvictOldCacheFiles_HonorsCustomCap` — non-default cap parameter exercised.
- `TestCacheMaxFiles_EnvOverride` — `BMAD_CACHE_MAX_FILES` parsing matrix (unset, valid, zero, negative, garbage, whitespace-padded).

### Part (a) — atlas dep bump to v0.1.2 (commit `4d13dbc`)

Phase 10 pinned atlas at the commit pseudo-version `v0.0.0-20260518085730-ae2e4e1b51d2`. The atlas team has since published v0.1.0 → v0.1.2.

- `go.mod`: `github.com/sosalejandro/atlas` → `v0.1.2`
- `go.sum`: refreshed via `go mod tidy`
- No call-site changes required — the codeindex public API (`IndexProject`, `Options`, `Index`, `Graph`, `Symbol`, `NopLogger`) is unchanged across these versions.

**Anti-stall note:** prior Batch F / F-retry stalled at `go mod tidy` for 10–15 min each (watchdog timeouts). On this run `tidy` returned in <1s — module proxy already had v0.1.2 cached locally. The 5-minute time-box recommended by the task spec was never hit.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New eviction unit tests pass (`go test -run 'Evict|CacheMaxFiles' ./application/sprint/...`)
- [x] All other previously-passing tests in `application/sprint/` still pass against atlas v0.1.2 (`go test -run 'TestBuildCodeContextSection|TestBuildStoryContext_IncludesAtlasSection|TestBuildStoryContext_OmitsAtlasSection' ./application/sprint/...`)
- [ ] **Known pre-existing failure:** `TestBuildStoryContext_NutritionV2Go_Story12_NoExistingFiles` fails on both this branch AND untouched `origin/v2`. Reason: it asserts the atlas section is omitted because `src/shared/application/services/save_with_events.go` doesn't exist in the local nutrition-v2-go checkout, but that file has since been created in the user's working copy. Test is environment-dependent and unrelated to the changes in this PR. Should be fixed in a follow-up.

## Notes

- PR base is `v2`, not `main` — auto-close of #12 won't fire on merge. The merger should manually close #12 with a reference comment.
- Eviction commit was pushed before attempting the atlas bump (anti-stall guidance: ensure progress is recoverable even if `go mod tidy` had hung again).