### PR TITLE
feat(sprint): infer-deps — derive depends_on from prose Given/Refs (closes #19)

### DIFF
--- a/application/sprint/inferdeps/command.go
+++ b/application/sprint/inferdeps/command.go
@@ -1,0 +1,61 @@
+package inferdeps
+
+// RunOptions parameterises the end-to-end "parse → resolve → emit" flow.
+// Kept separate from the cobra command so tests can drive the pipeline
+// without cobra mechanics.
+type RunOptions struct {
+	EpicsPath         string // required — path to epics.md
+	ScopeEpic         string // optional — restrict suggestions to one epic id
+	Apply             bool   // when true, rewrite the file in place
+	Backup            bool   // only meaningful with Apply=true; writes .bak
+	IntraEpicFallback bool   // when true, enable LOW-confidence X.Y → X.(Y-1)
+}
+
+// Run executes the pipeline and returns a populated PatchResult. The
+// cobra adapter wraps this in either text-mode or json-mode emission.
+func Run(opts RunOptions) (*PatchResult, []string, error) {
+	parsed, err := ParseEpics(opts.EpicsPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	sugs := Resolve(parsed, opts.IntraEpicFallback)
+	sugs = FilterByEpic(sugs, opts.ScopeEpic)
+
+	withCues := 0
+	withNew := 0
+	for _, s := range sugs {
+		if len(s.InferredDeps) > 0 {
+			withCues++
+		}
+		if len(s.NewDeps()) > 0 {
+			withNew++
+		}
+	}
+	agg := ComputeAgreement(sugs)
+
+	result := &PatchResult{
+		EpicsFile:         opts.EpicsPath,
+		TotalStories:      len(sugs),
+		StoriesWithCues:   withCues,
+		StoriesWithNew:    withNew,
+		Suggestions:       sugs,
+		ScopeEpic:         opts.ScopeEpic,
+		IntraEpicFallback: opts.IntraEpicFallback,
+		Agreement:         &agg,
+	}
+
+	var warnings []string
+	if opts.Apply {
+		patched, backupPath, skipped, aerr := ApplyPatches(opts.EpicsPath, sugs, opts.Backup)
+		if aerr != nil {
+			return result, nil, aerr
+		}
+		result.Applied = true
+		result.StoriesPatched = patched
+		result.BackupPath = backupPath
+		for _, sid := range skipped {
+			warnings = append(warnings, "skipped story "+sid+" — no existing frontmatter to patch (insert one first)")
+		}
+	}
+	return result, warnings, nil
+}

--- a/application/sprint/inferdeps/parser.go
+++ b/application/sprint/inferdeps/parser.go
@@ -1,0 +1,247 @@
+// Package inferdeps parses epics.md prose for dependency cues (**Given**,
+// **Refs**, epic-level prose) and turns them into suggested `depends_on:`
+// YAML patches per story.
+//
+// The package is deterministic and read-only: it never mutates the source
+// epics.md file unless `--apply` is passed via the cobra wrapper, and even
+// then the mutation is a targeted YAML-frontmatter rewrite per story.
+package inferdeps
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// EpicHeader captures the `## Epic N: Slice <s> — <name>` line metadata.
+// We track the slice tag (e.g. "0a", "1", "13") because **Given** prose
+// commonly references "Slice 0a" rather than "Epic 1".
+type EpicHeader struct {
+	EpicID  string // "1", "10", "22"
+	Slice   string // "0a", "1", "13" — empty when header has no "Slice <x>" tag
+	Name    string // the human-readable trailing name
+	LineNum int    // 1-based line in source
+}
+
+// StoryProse holds the per-story raw prose cues the resolver consumes.
+// Only fields meaningful for dependency inference are populated; the
+// original sprint.ParseEpicsFile handles full frontmatter parsing.
+type StoryProse struct {
+	StoryID string // "4.2"
+	Title   string // "Identity Canonical Service Shape"
+	EpicID  string // the epic header in effect when this story was parsed
+	Slice   string // ditto — Slice tag from the parent epic, may be empty
+	LineNum int    // 1-based line where `### Story X.Y` appeared
+
+	// FrontmatterDependsOn is the depends_on list already declared in the
+	// frontmatter (if any). When the resolver suggests deps, this lets the
+	// patch emitter distinguish "new" vs "already-present" cues, and the
+	// validation harness compute an agreement rate.
+	FrontmatterDependsOn []string
+
+	// HasFrontmatter mirrors sprint.ParsedStory.HasFrontmatter so callers
+	// can decide whether to emit a full frontmatter block (no existing
+	// frontmatter) vs. an in-place depends_on patch.
+	HasFrontmatter bool
+
+	// GivenLines are the raw text after the `**Given**` marker on each
+	// matching line, with the marker + bullet prefix stripped. One entry
+	// per `**Given**` cue (most stories have exactly one).
+	GivenLines []string
+
+	// RefsLines are the raw text after `**Refs:**`. Most stories have one.
+	RefsLines []string
+}
+
+// ParsedEpicsProse is the full result of parsing one epics.md file. Epics
+// is kept (rather than only stories) so the resolver can answer "which
+// epic owns slice 0c?" without re-walking.
+type ParsedEpicsProse struct {
+	Epics   []EpicHeader
+	Stories []StoryProse
+}
+
+var (
+	epicHeaderRE  = regexp.MustCompile(`^##\s+Epic\s+(\d+)\s*[:\-]\s*(.+)$`)
+	sliceTagRE    = regexp.MustCompile(`Slice\s+([0-9]+[a-z]?)`)
+	storyHeaderRE = regexp.MustCompile(`^###\s+Story\s+([\w.\-]+)\s*[:\-]\s*(.+)$`)
+
+	// `- **Given** ...`, `**Given** ...`, `- **Given:** ...`, etc.
+	givenLineRE = regexp.MustCompile(`^\s*(?:-\s+)?\*\*Given\*\*[:\s]*(.+)$`)
+	refsLineRE  = regexp.MustCompile(`^\s*(?:-\s+)?\*\*Refs:?\*\*[:\s]*(.+)$`)
+
+	dependsOnLineRE = regexp.MustCompile(`^\s*depends_on\s*:\s*\[(.*)\]\s*$`)
+	yamlItemRE      = regexp.MustCompile(`"([^"]+)"|'([^']+)'|([^\s,]+)`)
+)
+
+// ParseEpics reads an epics.md file and extracts every epic header + every
+// story body's `**Given**` / `**Refs**` cues. The output is intentionally
+// minimal — downstream resolution lives in resolver.go.
+func ParseEpics(path string) (*ParsedEpicsProse, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("inferdeps: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	out := &ParsedEpicsProse{}
+
+	var (
+		currentEpic    *EpicHeader
+		currentStory   *StoryProse
+		inYAML         bool
+		yamlBuf        strings.Builder
+		lineNum        int
+	)
+
+	flushStory := func() {
+		if currentStory == nil {
+			return
+		}
+		// Persist any frontmatter-derived depends_on the resolver should
+		// honor as "already declared".
+		if yamlBuf.Len() > 0 {
+			currentStory.FrontmatterDependsOn = extractFrontmatterDependsOn(yamlBuf.String())
+			currentStory.HasFrontmatter = true
+		}
+		out.Stories = append(out.Stories, *currentStory)
+		currentStory = nil
+		yamlBuf.Reset()
+		inYAML = false
+	}
+
+	scan := bufio.NewScanner(f)
+	scan.Buffer(make([]byte, 1<<20), 1<<20)
+	for scan.Scan() {
+		lineNum++
+		line := scan.Text()
+
+		// Epic header
+		if m := epicHeaderRE.FindStringSubmatch(line); m != nil {
+			flushStory()
+			eh := EpicHeader{
+				EpicID:  m[1],
+				Name:    strings.TrimSpace(m[2]),
+				LineNum: lineNum,
+			}
+			if sm := sliceTagRE.FindStringSubmatch(eh.Name); sm != nil {
+				eh.Slice = sm[1]
+			}
+			out.Epics = append(out.Epics, eh)
+			currentEpic = &out.Epics[len(out.Epics)-1]
+			continue
+		}
+
+		// Story header
+		if m := storyHeaderRE.FindStringSubmatch(line); m != nil {
+			flushStory()
+			s := StoryProse{
+				StoryID: m[1],
+				Title:   strings.TrimSpace(m[2]),
+				LineNum: lineNum,
+			}
+			if currentEpic != nil {
+				s.EpicID = currentEpic.EpicID
+				s.Slice = currentEpic.Slice
+			}
+			currentStory = &s
+			continue
+		}
+
+		if currentStory == nil {
+			continue
+		}
+
+		// YAML frontmatter detection — collect the body verbatim so we
+		// can pull depends_on out of it later.
+		if strings.TrimSpace(line) == "---" {
+			inYAML = !inYAML
+			continue
+		}
+		if inYAML {
+			yamlBuf.WriteString(line)
+			yamlBuf.WriteString("\n")
+			continue
+		}
+
+		// `**Given** ...` cue
+		if m := givenLineRE.FindStringSubmatch(line); m != nil {
+			currentStory.GivenLines = append(currentStory.GivenLines, strings.TrimSpace(m[1]))
+			continue
+		}
+		// `**Refs:** ...` cue
+		if m := refsLineRE.FindStringSubmatch(line); m != nil {
+			currentStory.RefsLines = append(currentStory.RefsLines, strings.TrimSpace(m[1]))
+			continue
+		}
+	}
+	if err := scan.Err(); err != nil {
+		return nil, fmt.Errorf("inferdeps: scan %s: %w", path, err)
+	}
+	flushStory()
+	return out, nil
+}
+
+// extractFrontmatterDependsOn pulls the depends_on list out of a YAML
+// frontmatter block. We deliberately do NOT use a full YAML decoder here
+// — the inferred-deps tool only cares about the depends_on shape, and a
+// hand-rolled extractor is bulletproof against the messy free-form
+// frontmatter shapes the nutrition team uses in practice (e.g. trailing
+// commas, mixed quote styles, multi-line block lists).
+func extractFrontmatterDependsOn(yamlBody string) []string {
+	scan := bufio.NewScanner(strings.NewReader(yamlBody))
+	var (
+		out         []string
+		inBlockList bool
+	)
+	for scan.Scan() {
+		raw := scan.Text()
+		trim := strings.TrimSpace(raw)
+
+		// Inline form: depends_on: ["1.1", "2.3"]
+		if m := dependsOnLineRE.FindStringSubmatch(raw); m != nil {
+			for _, item := range yamlItemRE.FindAllStringSubmatch(m[1], -1) {
+				val := firstNonEmpty(item[1], item[2], item[3])
+				if val != "" {
+					out = append(out, val)
+				}
+			}
+			inBlockList = false
+			continue
+		}
+
+		// Block-list form:
+		//   depends_on:
+		//     - "1.1"
+		//     - "2.3"
+		if strings.HasPrefix(trim, "depends_on:") && !strings.Contains(trim, "[") {
+			inBlockList = true
+			continue
+		}
+
+		if inBlockList {
+			if strings.HasPrefix(trim, "- ") {
+				item := strings.TrimPrefix(trim, "- ")
+				item = strings.Trim(item, `"'`)
+				if item != "" {
+					out = append(out, item)
+				}
+				continue
+			}
+			// Any non-list-item line ends the block.
+			inBlockList = false
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/application/sprint/inferdeps/parser_test.go
+++ b/application/sprint/inferdeps/parser_test.go
@@ -1,0 +1,155 @@
+package inferdeps_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint/inferdeps"
+)
+
+func writeEpics(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "epics.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write epics: %v", err)
+	}
+	return p
+}
+
+func TestParseEpics_CapturesGivenAndRefs(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a — Canonical Reference
+
+### Story 1.1: Pick Reference BC
+
+---
+story_id: "1.1"
+depends_on: []
+---
+
+- **Given** the 27-BC inventory
+- **When** I pick a candidate
+- **Then** the choice is documented
+- **Refs:** FR-Arch-7
+
+### Story 1.2: Document Helper
+
+---
+story_id: "1.2"
+depends_on: ["1.1"]
+---
+
+- **Given** measurements BC chosen as reference
+- **Refs:** FR-Arch-2
+`)
+	parsed, err := inferdeps.ParseEpics(path)
+	if err != nil {
+		t.Fatalf("ParseEpics: %v", err)
+	}
+	if len(parsed.Epics) != 1 {
+		t.Fatalf("Epics=%d, want 1", len(parsed.Epics))
+	}
+	if parsed.Epics[0].EpicID != "1" || parsed.Epics[0].Slice != "0a" {
+		t.Errorf("epic[0]=%+v, want EpicID=1 Slice=0a", parsed.Epics[0])
+	}
+	if len(parsed.Stories) != 2 {
+		t.Fatalf("Stories=%d, want 2", len(parsed.Stories))
+	}
+	s := parsed.Stories[0]
+	if s.StoryID != "1.1" || s.Title != "Pick Reference BC" {
+		t.Errorf("story[0]=%+v, want 1.1", s)
+	}
+	if len(s.GivenLines) != 1 || s.GivenLines[0] != "the 27-BC inventory" {
+		t.Errorf("Given=%v", s.GivenLines)
+	}
+	if len(s.RefsLines) != 1 || s.RefsLines[0] != "FR-Arch-7" {
+		t.Errorf("Refs=%v", s.RefsLines)
+	}
+	if s.EpicID != "1" || s.Slice != "0a" {
+		t.Errorf("inherited epic ctx = %+v", s)
+	}
+
+	s2 := parsed.Stories[1]
+	if len(s2.FrontmatterDependsOn) != 1 || s2.FrontmatterDependsOn[0] != "1.1" {
+		t.Errorf("FrontmatterDependsOn = %v", s2.FrontmatterDependsOn)
+	}
+	if !s2.HasFrontmatter {
+		t.Errorf("HasFrontmatter should be true")
+	}
+}
+
+func TestParseEpics_BlockListDependsOn(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 4: Slice 1 — identity BC
+
+### Story 4.3: Identity *WithID Methods
+
+---
+story_id: "4.3"
+depends_on:
+  - "4.2"
+  - "3.6"
+complexity: low
+---
+
+- **Given** canonical service in place
+- **Refs:** FR-Arch-2
+`)
+	parsed, err := inferdeps.ParseEpics(path)
+	if err != nil {
+		t.Fatalf("ParseEpics: %v", err)
+	}
+	if len(parsed.Stories) != 1 {
+		t.Fatalf("Stories=%d", len(parsed.Stories))
+	}
+	got := parsed.Stories[0].FrontmatterDependsOn
+	if len(got) != 2 || got[0] != "4.2" || got[1] != "3.6" {
+		t.Errorf("FrontmatterDependsOn=%v, want [4.2 3.6]", got)
+	}
+}
+
+func TestParseEpics_StoryWithoutFrontmatter(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 2: Slice 0b — Scaffolds
+
+### Story 2.1: Lint Config
+
+As a developer agent, I want lint enabled.
+
+- **Given** existing baseline
+- **Refs:** NFR-1
+`)
+	parsed, err := inferdeps.ParseEpics(path)
+	if err != nil {
+		t.Fatalf("ParseEpics: %v", err)
+	}
+	if len(parsed.Stories) != 1 {
+		t.Fatalf("Stories=%d", len(parsed.Stories))
+	}
+	if parsed.Stories[0].HasFrontmatter {
+		t.Errorf("HasFrontmatter should be false")
+	}
+	if len(parsed.Stories[0].GivenLines) != 1 {
+		t.Errorf("Given=%v", parsed.Stories[0].GivenLines)
+	}
+}
+
+func TestParseEpics_MultipleGivenLines(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a — Ref
+
+### Story 1.1: Multi-Given
+
+- **Given** prerequisite A
+- **Given** prerequisite B
+- **Refs:** FR-1, FR-2
+`)
+	parsed, err := inferdeps.ParseEpics(path)
+	if err != nil {
+		t.Fatalf("ParseEpics: %v", err)
+	}
+	if len(parsed.Stories[0].GivenLines) != 2 {
+		t.Errorf("Given=%v want 2 entries", parsed.Stories[0].GivenLines)
+	}
+}

--- a/application/sprint/inferdeps/patch.go
+++ b/application/sprint/inferdeps/patch.go
@@ -1,0 +1,278 @@
+package inferdeps
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// PatchResult is the structured JSON-mode envelope payload for the
+// command. Keeping it as a named struct (rather than map[string]any) gives
+// downstream consumers a stable shape they can decode into.
+type PatchResult struct {
+	EpicsFile         string       `json:"epics_file"`
+	TotalStories      int          `json:"total_stories"`
+	StoriesWithCues   int          `json:"stories_with_cues"`
+	StoriesWithNew    int          `json:"stories_with_new_deps"`
+	Suggestions       []Suggestion `json:"suggestions"`
+	Applied           bool         `json:"applied"`
+	StoriesPatched    int          `json:"stories_patched"`
+	BackupPath        string       `json:"backup_path,omitempty"`
+	ScopeEpic         string       `json:"scope_epic,omitempty"`
+	IntraEpicFallback bool         `json:"intra_epic_fallback"`
+	Agreement         *Agreement   `json:"agreement,omitempty"`
+}
+
+// Agreement is the tool-vs-manual alignment report — for any story that
+// has frontmatter depends_on AND the tool produced suggestions, we count
+// matches vs misses. The PR description / nutrition smoke uses this.
+type Agreement struct {
+	StoriesScored         int     `json:"stories_scored"`
+	InferredDepCount      int     `json:"inferred_dep_count"`
+	MatchedDepCount       int     `json:"matched_dep_count"`
+	AgreementRatePercent  float64 `json:"agreement_rate_percent"`
+	FrontmatterDepsTotal  int     `json:"frontmatter_deps_total"`
+}
+
+// EmitSummary writes a human-readable summary of suggestions to w. It's
+// the text-mode counterpart to the JSON envelope.
+func EmitSummary(w io.Writer, result *PatchResult) error {
+	fmt.Fprintf(w, "epics file: %s\n", result.EpicsFile)
+	if result.ScopeEpic != "" {
+		fmt.Fprintf(w, "scope: epic %s\n", result.ScopeEpic)
+	}
+	fmt.Fprintf(w, "stories: %d total | %d with inferred cues | %d with NEW deps\n",
+		result.TotalStories, result.StoriesWithCues, result.StoriesWithNew)
+	if result.Agreement != nil && result.Agreement.StoriesScored > 0 {
+		fmt.Fprintf(w, "agreement vs manual: %.1f%% (%d matched / %d inferred across %d scored stories)\n",
+			result.Agreement.AgreementRatePercent,
+			result.Agreement.MatchedDepCount,
+			result.Agreement.InferredDepCount,
+			result.Agreement.StoriesScored)
+	}
+	fmt.Fprintln(w)
+
+	for _, sug := range result.Suggestions {
+		newDeps := sug.NewDeps()
+		if len(newDeps) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "# Suggested for Story %s — %s\n", sug.StoryID, sug.Title)
+		// Render merged list as the actual yaml fragment the operator
+		// pastes in. New ids are flagged inline so reviewers see what's
+		// being added.
+		merged := sug.MergedDeps()
+		fmt.Fprintf(w, "depends_on: [%s]\n", joinYAMLStrings(merged))
+		for _, d := range newDeps {
+			fmt.Fprintf(w, "  # + %s  (%s, via %s — %q)\n", d.DepID, d.Confidence, d.Source, d.Cue)
+		}
+		fmt.Fprintln(w)
+	}
+	if result.Applied {
+		fmt.Fprintf(w, "applied: rewrote %d stories in %s\n", result.StoriesPatched, result.EpicsFile)
+		if result.BackupPath != "" {
+			fmt.Fprintf(w, "backup: %s\n", result.BackupPath)
+		}
+	}
+	return nil
+}
+
+func joinYAMLStrings(ids []string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = fmt.Sprintf("%q", id)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ComputeAgreement scores tool suggestions against existing frontmatter
+// depends_on entries. Only stories that have BOTH frontmatter deps AND at
+// least one inferred dep contribute to the score.
+func ComputeAgreement(sugs []Suggestion) Agreement {
+	agg := Agreement{}
+	for _, s := range sugs {
+		if len(s.FrontmatterDependsOn) == 0 {
+			continue
+		}
+		agg.FrontmatterDepsTotal += len(s.FrontmatterDependsOn)
+		if len(s.InferredDeps) == 0 {
+			continue
+		}
+		agg.StoriesScored++
+		agg.InferredDepCount += len(s.InferredDeps)
+		agg.MatchedDepCount += len(s.MatchedDeps())
+	}
+	if agg.InferredDepCount > 0 {
+		agg.AgreementRatePercent = 100.0 *
+			float64(agg.MatchedDepCount) / float64(agg.InferredDepCount)
+	}
+	return agg
+}
+
+// FilterByEpic keeps only suggestions whose StoryID belongs to the given
+// epic id. Empty epicID is a no-op (returns the input unchanged).
+func FilterByEpic(sugs []Suggestion, epicID string) []Suggestion {
+	if epicID == "" {
+		return sugs
+	}
+	var out []Suggestion
+	for _, s := range sugs {
+		if s.EpicID == epicID {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ApplyPatches rewrites the epics.md file in place: for each story that
+// has frontmatter AND new inferred deps, the existing `depends_on:` line
+// (or the block-list form) is replaced with the merged list. Stories
+// without frontmatter are skipped (warning surfaced through the returned
+// skipped-list). The result is byte-identical to the input EXCEPT for the
+// rewritten depends_on lines.
+//
+// When backup is true a `.bak` copy of the original is written next to
+// the source.
+func ApplyPatches(epicsPath string, sugs []Suggestion, backup bool) (patched int, backupPath string, skipped []string, err error) {
+	// Index suggestions by story id for quick lookup while walking.
+	byID := map[string]Suggestion{}
+	for _, s := range sugs {
+		if len(s.NewDeps()) == 0 {
+			continue
+		}
+		if !s.HasFrontmatter {
+			skipped = append(skipped, s.StoryID)
+			continue
+		}
+		byID[s.StoryID] = s
+	}
+	if len(byID) == 0 {
+		return 0, "", skipped, nil
+	}
+
+	src, err := os.ReadFile(epicsPath)
+	if err != nil {
+		return 0, "", skipped, fmt.Errorf("read %s: %w", epicsPath, err)
+	}
+	if backup {
+		backupPath = epicsPath + ".bak"
+		if werr := os.WriteFile(backupPath, src, 0o644); werr != nil {
+			return 0, "", skipped, fmt.Errorf("write backup %s: %w", backupPath, werr)
+		}
+	}
+
+	out, n := rewriteDependsOn(string(src), byID)
+
+	if werr := os.WriteFile(epicsPath, []byte(out), 0o644); werr != nil {
+		return 0, backupPath, skipped, fmt.Errorf("write %s: %w", epicsPath, werr)
+	}
+	return n, backupPath, skipped, nil
+}
+
+var (
+	// Matches BOTH inline ("depends_on: [...]") and the start of a block
+	// form ("depends_on:" with no inline list).
+	depsLineRE       = regexp.MustCompile(`^(\s*depends_on\s*:)\s*(.*)$`)
+	storyHeaderApply = regexp.MustCompile(`^###\s+Story\s+([\w.\-]+)\s*[:\-]\s*(.+)$`)
+)
+
+// rewriteDependsOn does the in-place text replacement. We walk lines and
+// track:
+//   currentStoryID: which story's frontmatter (if any) we're inside
+//   inYAML:         whether we're between `---` delimiters
+//   inBlockList:    whether we're consuming a multi-line depends_on block
+//                   that we need to skip (its replacement has already been
+//                   emitted before this block).
+func rewriteDependsOn(src string, byID map[string]Suggestion) (string, int) {
+	var (
+		buf            strings.Builder
+		currentStory   string
+		inYAML         bool
+		inBlockSkip    bool
+		patched        = 0
+		hasDependsLine = map[string]bool{}
+	)
+	scan := bufio.NewScanner(strings.NewReader(src))
+	scan.Buffer(make([]byte, 1<<20), 1<<20)
+	for scan.Scan() {
+		line := scan.Text()
+
+		if m := storyHeaderApply.FindStringSubmatch(line); m != nil {
+			currentStory = m[1]
+			inYAML = false
+			inBlockSkip = false
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+			continue
+		}
+
+		if strings.TrimSpace(line) == "---" && currentStory != "" {
+			// Frontmatter open/close. On close, if this story was supposed
+			// to get a depends_on rewrite but had none, the line never
+			// fired — handled below.
+			if inYAML && !hasDependsLine[currentStory] {
+				if sug, ok := byID[currentStory]; ok {
+					buf.WriteString(renderDependsOnLine(sug))
+				}
+			}
+			inYAML = !inYAML
+			inBlockSkip = false
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+			continue
+		}
+
+		if inYAML {
+			// Continue skipping a block-list we already replaced.
+			if inBlockSkip {
+				trim := strings.TrimSpace(line)
+				if strings.HasPrefix(trim, "- ") || trim == "" {
+					// Treat empty line as terminator for safety — many epic
+					// authors use blank lines after a list. Continue skipping
+					// only true list-item lines.
+					if strings.HasPrefix(trim, "- ") {
+						continue
+					}
+					inBlockSkip = false
+					buf.WriteString(line)
+					buf.WriteByte('\n')
+					continue
+				}
+				inBlockSkip = false
+				// Fallthrough to write the non-list line.
+			}
+
+			if m := depsLineRE.FindStringSubmatch(line); m != nil {
+				hasDependsLine[currentStory] = true
+				if sug, ok := byID[currentStory]; ok {
+					buf.WriteString(renderDependsOnLine(sug))
+					patched++
+					inline := strings.TrimSpace(m[2])
+					if inline == "" {
+						// block-list form — skip subsequent `- ` lines
+						inBlockSkip = true
+					}
+					continue
+				}
+				// No suggestion for this story; keep the line as-is.
+				buf.WriteString(line)
+				buf.WriteByte('\n')
+				continue
+			}
+		}
+
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	return buf.String(), patched
+}
+
+func renderDependsOnLine(s Suggestion) string {
+	return fmt.Sprintf("depends_on: [%s]\n", joinYAMLStrings(s.MergedDeps()))
+}

--- a/application/sprint/inferdeps/patch_test.go
+++ b/application/sprint/inferdeps/patch_test.go
@@ -1,0 +1,214 @@
+package inferdeps_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint/inferdeps"
+)
+
+func TestEmitSummary_RendersNewDepsBlock(t *testing.T) {
+	t.Parallel()
+	sugs := []inferdeps.Suggestion{
+		{
+			StoryID: "4.2",
+			Title:   "Identity Canonical Service",
+			EpicID:  "4",
+			FrontmatterDependsOn: []string{"4.1"},
+			HasFrontmatter:       true,
+			InferredDeps: []inferdeps.Inferred{
+				{StoryID: "4.2", DepID: "4.1", Confidence: inferdeps.ConfidenceHigh, Cue: "Story 4.1 emits events", Source: "given"},
+				{StoryID: "4.2", DepID: "1.4", Confidence: inferdeps.ConfidenceMedium, Cue: "Slice 0a complete", Source: "given"},
+			},
+		},
+	}
+	result := &inferdeps.PatchResult{
+		EpicsFile: "/tmp/epics.md",
+		Suggestions: sugs,
+		TotalStories: 1,
+		StoriesWithCues: 1,
+		StoriesWithNew: 1,
+	}
+	var buf bytes.Buffer
+	if err := inferdeps.EmitSummary(&buf, result); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Story 4.2") {
+		t.Errorf("missing story heading: %s", out)
+	}
+	if !strings.Contains(out, `depends_on: ["1.4", "4.1"]`) {
+		t.Errorf("missing merged depends_on with 1.4 added: %s", out)
+	}
+	if !strings.Contains(out, "+ 1.4") {
+		t.Errorf("missing new-dep annotation: %s", out)
+	}
+}
+
+func TestComputeAgreement_OverlapBetweenInferredAndFrontmatter(t *testing.T) {
+	t.Parallel()
+	sugs := []inferdeps.Suggestion{
+		{ // 1 match out of 1 inferred (100%)
+			StoryID:              "4.1",
+			FrontmatterDependsOn: []string{"3.6"},
+			InferredDeps: []inferdeps.Inferred{
+				{StoryID: "4.1", DepID: "3.6", Confidence: inferdeps.ConfidenceMedium},
+			},
+		},
+		{ // 0 matches out of 1 inferred (0%) — tool found a new one
+			StoryID:              "4.2",
+			FrontmatterDependsOn: []string{"4.1"},
+			InferredDeps: []inferdeps.Inferred{
+				{StoryID: "4.2", DepID: "1.4", Confidence: inferdeps.ConfidenceMedium},
+			},
+		},
+		{ // No inferred deps → not counted in score
+			StoryID:              "4.3",
+			FrontmatterDependsOn: []string{"4.2"},
+		},
+	}
+	a := inferdeps.ComputeAgreement(sugs)
+	if a.StoriesScored != 2 {
+		t.Errorf("StoriesScored = %d, want 2", a.StoriesScored)
+	}
+	if a.InferredDepCount != 2 || a.MatchedDepCount != 1 {
+		t.Errorf("counts = %d/%d, want 1/2", a.MatchedDepCount, a.InferredDepCount)
+	}
+	if a.AgreementRatePercent < 49 || a.AgreementRatePercent > 51 {
+		t.Errorf("rate = %.1f, want ~50", a.AgreementRatePercent)
+	}
+}
+
+func TestApplyPatches_RewritesInlineDependsOn(t *testing.T) {
+	t.Parallel()
+	src := `## Epic 4: Slice 1 — identity
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+complexity: medium
+---
+
+- **Given** Story 4.1 emits events
+- **Given** Slice 0a helper available
+`
+	path := writeEpics(t, src)
+	parsed, _ := inferdeps.ParseEpics(path)
+	// craft a richer fixture with Epic 1 + 4.1 so resolver has targets
+	full := `## Epic 1: Slice 0a — Reference
+
+### Story 1.1: Pick BC
+### Story 1.4: Verify task check
+
+## Epic 4: Slice 1 — identity
+
+### Story 4.1: Aggregates
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+complexity: medium
+---
+
+- **Given** Story 4.1 emits events
+- **Given** Slice 0a helper available
+`
+	path = writeEpics(t, full)
+	parsed, _ = inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+
+	patched, backupPath, skipped, err := inferdeps.ApplyPatches(path, sugs, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched != 1 {
+		t.Errorf("patched=%d, want 1", patched)
+	}
+	if backupPath == "" {
+		t.Errorf("backup path should be set")
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped should be empty (story has frontmatter), got %v", skipped)
+	}
+
+	after, _ := os.ReadFile(path)
+	if !strings.Contains(string(after), `depends_on: ["1.4", "4.1"]`) {
+		t.Errorf("rewrite missing merged depends_on:\n%s", string(after))
+	}
+	// Verify backup is the original (with the old depends_on).
+	back, _ := os.ReadFile(backupPath)
+	if !strings.Contains(string(back), `depends_on: ["4.1"]`) {
+		t.Errorf("backup should contain original line:\n%s", string(back))
+	}
+}
+
+func TestApplyPatches_BlockListFormReplaced(t *testing.T) {
+	t.Parallel()
+	src := `## Epic 1: Slice 0a — Reference
+
+### Story 1.4: Verify
+
+## Epic 4: Slice 1 — identity
+
+### Story 4.1: Aggregates
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on:
+  - "4.1"
+complexity: medium
+---
+
+- **Given** Slice 0a helper available
+`
+	path := writeEpics(t, src)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+
+	patched, _, _, err := inferdeps.ApplyPatches(path, sugs, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched != 1 {
+		t.Errorf("patched=%d, want 1", patched)
+	}
+	after, _ := os.ReadFile(path)
+	// Block-list collapsed into inline form post-apply (acceptable for v1).
+	if !strings.Contains(string(after), `depends_on: ["1.4", "4.1"]`) {
+		t.Errorf("rewrite missing merged list:\n%s", string(after))
+	}
+	// The old `- "4.1"` line must be gone.
+	if strings.Contains(string(after), `  - "4.1"`) {
+		t.Errorf("block-list residue should be removed:\n%s", string(after))
+	}
+	// complexity must still be present.
+	if !strings.Contains(string(after), `complexity: medium`) {
+		t.Errorf("apply mangled the rest of the frontmatter:\n%s", string(after))
+	}
+}
+
+func TestFilterByEpic_KeepsOnlyMatchingStories(t *testing.T) {
+	t.Parallel()
+	sugs := []inferdeps.Suggestion{
+		{StoryID: "1.1", EpicID: "1"},
+		{StoryID: "4.1", EpicID: "4"},
+		{StoryID: "4.2", EpicID: "4"},
+		{StoryID: "10.3", EpicID: "10"},
+	}
+	out := inferdeps.FilterByEpic(sugs, "4")
+	if len(out) != 2 || out[0].StoryID != "4.1" || out[1].StoryID != "4.2" {
+		t.Errorf("filtered = %+v, want [4.1 4.2]", out)
+	}
+	// "" is no-op
+	if len(inferdeps.FilterByEpic(sugs, "")) != 4 {
+		t.Errorf("empty epic filter should be no-op")
+	}
+}

--- a/application/sprint/inferdeps/resolver.go
+++ b/application/sprint/inferdeps/resolver.go
@@ -1,0 +1,377 @@
+package inferdeps
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Confidence labels per inferred dep. HIGH = explicit story id; MEDIUM =
+// slice/epic name resolved through the lookup table; LOW = intra-epic
+// fallback (Story X.Y → X.(Y-1) when no other cues fired).
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "HIGH"
+	ConfidenceMedium Confidence = "MEDIUM"
+	ConfidenceLow    Confidence = "LOW"
+)
+
+// Inferred is one suggested dependency for one story. The (StoryID, DepID)
+// pair is unique within a single resolver run.
+type Inferred struct {
+	StoryID    string     `json:"story_id"`
+	DepID      string     `json:"dep_id"`
+	Confidence Confidence `json:"confidence"`
+	Cue        string     `json:"cue"`     // the raw substring that triggered the inference
+	Source     string     `json:"source"`  // "given" | "intra-epic" | "refs"
+}
+
+// Suggestion is the per-story aggregate. Deps are sorted (story-id natural
+// order), deduplicated, and never contain self-references.
+type Suggestion struct {
+	StoryID              string     `json:"story_id"`
+	Title                string     `json:"title"`
+	EpicID               string     `json:"epic_id"`
+	InferredDeps         []Inferred `json:"inferred_deps"`
+	FrontmatterDependsOn []string   `json:"frontmatter_depends_on"`
+	HasFrontmatter       bool       `json:"has_frontmatter"`
+}
+
+// MergedDeps returns the union of frontmatter-declared + inferred dep ids,
+// deduped, sorted in natural story-id order. Useful for `--apply` patches
+// that need a complete depends_on list.
+func (s Suggestion) MergedDeps() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, d := range s.FrontmatterDependsOn {
+		if !seen[d] {
+			seen[d] = true
+			out = append(out, d)
+		}
+	}
+	for _, d := range s.InferredDeps {
+		if !seen[d.DepID] {
+			seen[d.DepID] = true
+			out = append(out, d.DepID)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return naturalLess(out[i], out[j]) })
+	return out
+}
+
+// NewDeps returns the inferred deps NOT already present in the frontmatter.
+// This is what an operator wants when reviewing dry-run output — they only
+// need to consider novel suggestions.
+func (s Suggestion) NewDeps() []Inferred {
+	have := map[string]bool{}
+	for _, d := range s.FrontmatterDependsOn {
+		have[d] = true
+	}
+	var out []Inferred
+	for _, d := range s.InferredDeps {
+		if !have[d.DepID] {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// MatchedDeps returns the inferred deps that were already in the frontmatter.
+// Used by the agreement-rate harness to compute tool-vs-manual alignment.
+func (s Suggestion) MatchedDeps() []Inferred {
+	have := map[string]bool{}
+	for _, d := range s.FrontmatterDependsOn {
+		have[d] = true
+	}
+	var out []Inferred
+	for _, d := range s.InferredDeps {
+		if have[d.DepID] {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// Resolve turns parsed prose into Suggestion entries. The resolver is
+// deterministic: same input → same output, ordering included.
+//
+//	enableIntraEpic: when true, stories with no other inferred deps and
+//	  StoryID == "X.Y" with Y > 1 get a LOW-confidence X.(Y-1) suggestion.
+//	  This is the "Story X.2 builds on X.1" heuristic — useful when prose
+//	  is sparse but cuts noise when prose is rich.
+func Resolve(parsed *ParsedEpicsProse, enableIntraEpic bool) []Suggestion {
+	if parsed == nil {
+		return nil
+	}
+
+	// Build helper indexes:
+	//   sliceToEpic: "0a" → "1", "13" → "16", ...
+	//   lastStoryOfEpic: "1" → "1.4", "4" → "4.12", ... (the highest
+	//     story id within each epic in DOCUMENT ORDER — i.e. the last one
+	//     that appears in the source file, which matches the intuitive
+	//     "epic 4 done" semantics).
+	//   storyExists: set of all story ids actually defined, so we can
+	//     filter inferences that point at non-existent ids.
+	sliceToEpic := map[string]string{}
+	for _, e := range parsed.Epics {
+		if e.Slice != "" {
+			sliceToEpic[e.Slice] = e.EpicID
+		}
+	}
+	lastStoryOfEpic := map[string]string{}
+	storyExists := map[string]bool{}
+	for _, s := range parsed.Stories {
+		storyExists[s.StoryID] = true
+		lastStoryOfEpic[s.EpicID] = s.StoryID
+	}
+
+	var out []Suggestion
+	for _, story := range parsed.Stories {
+		sug := Suggestion{
+			StoryID:              story.StoryID,
+			Title:                story.Title,
+			EpicID:               story.EpicID,
+			FrontmatterDependsOn: append([]string(nil), story.FrontmatterDependsOn...),
+			HasFrontmatter:       story.HasFrontmatter,
+		}
+
+		// Track de-dup within a single story's inferences.
+		seen := map[string]bool{}
+		add := func(depID string, conf Confidence, cue, source string) {
+			if depID == "" || depID == story.StoryID {
+				return
+			}
+			if !storyExists[depID] {
+				return
+			}
+			if seen[depID] {
+				return
+			}
+			seen[depID] = true
+			sug.InferredDeps = append(sug.InferredDeps, Inferred{
+				StoryID:    story.StoryID,
+				DepID:      depID,
+				Confidence: conf,
+				Cue:        cue,
+				Source:     source,
+			})
+		}
+
+		for _, g := range story.GivenLines {
+			extractCues(g, sliceToEpic, lastStoryOfEpic, story.StoryID, "given", add)
+		}
+		for _, r := range story.RefsLines {
+			extractCues(r, sliceToEpic, lastStoryOfEpic, story.StoryID, "refs", add)
+		}
+
+		if enableIntraEpic && len(sug.InferredDeps) == 0 {
+			if pred := intraEpicPredecessor(story.StoryID); pred != "" && storyExists[pred] {
+				add(pred, ConfidenceLow, "intra-epic fallback (Story X.Y → X.(Y-1))", "intra-epic")
+			}
+		}
+
+		// Stabilise order: confidence (HIGH > MEDIUM > LOW) then natural
+		// story-id order. Stable output keeps tests + diffs predictable.
+		sort.SliceStable(sug.InferredDeps, func(i, j int) bool {
+			ci, cj := confRank(sug.InferredDeps[i].Confidence), confRank(sug.InferredDeps[j].Confidence)
+			if ci != cj {
+				return ci < cj
+			}
+			return naturalLess(sug.InferredDeps[i].DepID, sug.InferredDeps[j].DepID)
+		})
+		out = append(out, sug)
+	}
+	return out
+}
+
+// Cue patterns. We compile once; the resolver runs these per Given/Refs line.
+var (
+	// Explicit story id reference. Matches:
+	//   Story 4.1
+	//   Story 1.1.foo-bar
+	//   story 10.3
+	storyMentionRE = regexp.MustCompile(`(?i)Story\s+([0-9]+\.[0-9A-Za-z._\-]+)`)
+
+	// "Slice 0a", "Slice 13", "Slices 1-5" (we only fire on the first id in a range)
+	sliceMentionRE = regexp.MustCompile(`(?i)Slice[s]?\s+([0-9]+[a-z]?)(?:\s*[-–]\s*([0-9]+[a-z]?))?`)
+
+	// "Epic 4", "Epic 13"
+	epicMentionRE = regexp.MustCompile(`(?i)Epic\s+(\d+)`)
+)
+
+// extractCues runs every recogniser against one prose line.
+func extractCues(line string, sliceToEpic, lastStoryOfEpic map[string]string, selfID, source string, add func(string, Confidence, string, string)) {
+	// 1) explicit story id — HIGH
+	for _, m := range storyMentionRE.FindAllStringSubmatch(line, -1) {
+		add(m[1], ConfidenceHigh, condense(line), source)
+	}
+
+	// 2) slice mentions — MEDIUM (resolves to last-story-of-epic)
+	for _, m := range sliceMentionRE.FindAllStringSubmatch(line, -1) {
+		// Range form ("Slices 1-5"): map each id in the range that exists.
+		ids := []string{m[1]}
+		if m[2] != "" {
+			ids = append(ids, expandSliceRange(m[1], m[2])...)
+		}
+		for _, sid := range ids {
+			ep, ok := sliceToEpic[sid]
+			if !ok {
+				continue
+			}
+			last := lastStoryOfEpic[ep]
+			if last == "" || sameEpic(selfID, ep) {
+				// Skip when the slice references the same epic — we want
+				// cross-epic deps from slice mentions, not self-loops.
+				continue
+			}
+			add(last, ConfidenceMedium, condense(line), source)
+		}
+	}
+
+	// 3) epic mentions — MEDIUM
+	for _, m := range epicMentionRE.FindAllStringSubmatch(line, -1) {
+		ep := m[1]
+		if sameEpic(selfID, ep) {
+			continue
+		}
+		last := lastStoryOfEpic[ep]
+		if last == "" {
+			continue
+		}
+		add(last, ConfidenceMedium, condense(line), source)
+	}
+}
+
+// expandSliceRange returns the intermediate slice ids inside an "A-B"
+// pattern, exclusive of the endpoints (the caller already adds those).
+// Only numeric ids participate; "0a-0c" is not expanded (returns nothing
+// rather than guess).
+func expandSliceRange(a, b string) []string {
+	if !isAllDigits(a) || !isAllDigits(b) {
+		return nil
+	}
+	ai, bi := atoi(a), atoi(b)
+	if ai >= bi {
+		return nil
+	}
+	var out []string
+	for i := ai + 1; i < bi; i++ {
+		out = append(out, itoa(i))
+	}
+	out = append(out, b) // include endpoint
+	return out
+}
+
+// sameEpic checks if a story id and an epic id share the same epic prefix
+// (e.g. "4.2" and "4" → true).
+func sameEpic(storyID, epicID string) bool {
+	if i := strings.IndexByte(storyID, '.'); i >= 0 {
+		return storyID[:i] == epicID
+	}
+	return storyID == epicID
+}
+
+// intraEpicPredecessor returns "X.Y-1" when storyID is "X.Y" with integer
+// Y > 1. Returns "" otherwise (epic-level stories, sub-story ids, etc).
+func intraEpicPredecessor(storyID string) string {
+	parts := strings.SplitN(storyID, ".", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	suffix := parts[1]
+	// Only handle pure-numeric suffixes — "1.payment-method" doesn't get
+	// a fallback predecessor.
+	if !isAllDigits(suffix) {
+		return ""
+	}
+	n := atoi(suffix)
+	if n <= 1 {
+		return ""
+	}
+	return parts[0] + "." + itoa(n-1)
+}
+
+func confRank(c Confidence) int {
+	switch c {
+	case ConfidenceHigh:
+		return 0
+	case ConfidenceMedium:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// condense trims a cue down to a fixed length for output readability.
+func condense(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 96 {
+		return s[:93] + "..."
+	}
+	return s
+}
+
+// naturalLess compares two story ids like "4.10" and "4.2" as humans
+// expect (4.2 < 4.10). Pure lexicographic compare flips that.
+func naturalLess(a, b string) bool {
+	pa := strings.Split(a, ".")
+	pb := strings.Split(b, ".")
+	for i := 0; i < len(pa) && i < len(pb); i++ {
+		ai := atoi(pa[i])
+		bi := atoi(pb[i])
+		if isAllDigits(pa[i]) && isAllDigits(pb[i]) {
+			if ai != bi {
+				return ai < bi
+			}
+			continue
+		}
+		if pa[i] != pb[i] {
+			return pa[i] < pb[i]
+		}
+	}
+	return len(pa) < len(pb)
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return n
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/application/sprint/inferdeps/resolver_test.go
+++ b/application/sprint/inferdeps/resolver_test.go
@@ -1,0 +1,235 @@
+package inferdeps_test
+
+import (
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint/inferdeps"
+)
+
+func TestResolve_ExplicitStoryReferenceIsHIGH(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 4: Slice 1 — identity BC
+
+### Story 4.1: Identity Aggregates
+
+- **Given** baseline
+- **Refs:** FR-1
+
+### Story 4.2: Identity Canonical Service
+
+- **Given** Story 4.1 emits events through outbox
+- **Refs:** FR-2
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+	if len(sugs) != 2 {
+		t.Fatalf("len=%d, want 2", len(sugs))
+	}
+	s2 := sugs[1]
+	if len(s2.InferredDeps) != 1 || s2.InferredDeps[0].DepID != "4.1" {
+		t.Fatalf("inferred = %+v", s2.InferredDeps)
+	}
+	if s2.InferredDeps[0].Confidence != inferdeps.ConfidenceHigh {
+		t.Errorf("conf = %v, want HIGH", s2.InferredDeps[0].Confidence)
+	}
+}
+
+func TestResolve_SliceMentionResolvesToLastStoryOfEpicMEDIUM(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a — Reference
+
+### Story 1.1: Pick BC
+### Story 1.2: Doc Helper
+### Story 1.3: Walkthrough
+### Story 1.4: task check green
+
+## Epic 4: Slice 1 — identity
+
+### Story 4.1: Identity Aggregates
+
+- **Given** Slice 0a complete; saveWithEvents helper available
+- **Refs:** FR-Arch-1
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+	// Story 4.1 should infer dep on 1.4 (last story of epic 1, which owns slice 0a).
+	var s41 inferdeps.Suggestion
+	for _, s := range sugs {
+		if s.StoryID == "4.1" {
+			s41 = s
+		}
+	}
+	if len(s41.InferredDeps) != 1 || s41.InferredDeps[0].DepID != "1.4" {
+		t.Fatalf("4.1 inferred = %+v", s41.InferredDeps)
+	}
+	if s41.InferredDeps[0].Confidence != inferdeps.ConfidenceMedium {
+		t.Errorf("conf = %v, want MEDIUM", s41.InferredDeps[0].Confidence)
+	}
+}
+
+func TestResolve_IntraEpicFallbackLOWOnlyWhenEnabled(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a
+
+### Story 1.1: First
+### Story 1.2: Second
+
+- **Given** the previous story completed
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+
+	noFallback := inferdeps.Resolve(parsed, false)
+	for _, s := range noFallback {
+		if s.StoryID == "1.2" && len(s.InferredDeps) != 0 {
+			t.Errorf("with fallback OFF, 1.2 inferred = %+v", s.InferredDeps)
+		}
+	}
+
+	withFallback := inferdeps.Resolve(parsed, true)
+	var s12 inferdeps.Suggestion
+	for _, s := range withFallback {
+		if s.StoryID == "1.2" {
+			s12 = s
+		}
+	}
+	if len(s12.InferredDeps) != 1 || s12.InferredDeps[0].DepID != "1.1" {
+		t.Fatalf("with fallback ON, 1.2 inferred = %+v", s12.InferredDeps)
+	}
+	if s12.InferredDeps[0].Confidence != inferdeps.ConfidenceLow {
+		t.Errorf("conf = %v, want LOW", s12.InferredDeps[0].Confidence)
+	}
+}
+
+func TestResolve_NoSelfLoopFromSameEpicSliceMention(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a
+
+### Story 1.2: Second
+
+- **Given** Slice 0a foundation in place
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+	if len(sugs[0].InferredDeps) != 0 {
+		t.Errorf("self-epic slice mention should not infer dep; got %+v", sugs[0].InferredDeps)
+	}
+}
+
+func TestResolve_DedupesAndOrdersByConfidence(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 1: Slice 0a
+
+### Story 1.1: A
+### Story 1.2: B
+
+## Epic 4: Slice 1
+
+### Story 4.1: Mix
+
+- **Given** Story 1.2 ready and Slice 0a foundation done
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+	var s41 inferdeps.Suggestion
+	for _, s := range sugs {
+		if s.StoryID == "4.1" {
+			s41 = s
+		}
+	}
+	// Should dedupe: "Slice 0a" → 1.2 (last of epic 1), "Story 1.2" → 1.2 explicit.
+	// Final list: one entry, HIGH confidence (HIGH wins via stable sort).
+	if len(s41.InferredDeps) != 1 {
+		t.Fatalf("expected 1 deduped dep, got %+v", s41.InferredDeps)
+	}
+	if s41.InferredDeps[0].DepID != "1.2" {
+		t.Errorf("dep id = %s, want 1.2", s41.InferredDeps[0].DepID)
+	}
+	if s41.InferredDeps[0].Confidence != inferdeps.ConfidenceHigh {
+		t.Errorf("conf = %v, want HIGH (HIGH must precede MEDIUM in dedup)", s41.InferredDeps[0].Confidence)
+	}
+}
+
+func TestResolve_MergedAndNewAndMatchedDeps(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 4: Slice 1
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+---
+
+- **Given** Story 4.1 emits events
+- **Given** Story 3.6 toolchain bumped
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	// 3.6 doesn't exist in source → filtered out. 4.1 is matched.
+	sugs := inferdeps.Resolve(parsed, false)
+	s := sugs[0]
+	// 4.1 doesn't exist either in this minimal fixture → it'd be filtered.
+	// Re-do with a richer fixture that contains 4.1.
+	path = writeEpics(t, `## Epic 3: Slice 0c
+
+### Story 3.6: Bump
+
+## Epic 4: Slice 1
+
+### Story 4.1: Aggregates
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+---
+
+- **Given** Story 4.1 emits events
+- **Given** Story 3.6 toolchain bumped
+`)
+	parsed, _ = inferdeps.ParseEpics(path)
+	sugs = inferdeps.Resolve(parsed, false)
+	for _, s = range sugs {
+		if s.StoryID == "4.2" {
+			break
+		}
+	}
+	merged := s.MergedDeps()
+	if len(merged) != 2 || merged[0] != "3.6" || merged[1] != "4.1" {
+		t.Errorf("merged = %v, want [3.6 4.1]", merged)
+	}
+	newDeps := s.NewDeps()
+	if len(newDeps) != 1 || newDeps[0].DepID != "3.6" {
+		t.Errorf("new = %+v, want [3.6]", newDeps)
+	}
+	matched := s.MatchedDeps()
+	if len(matched) != 1 || matched[0].DepID != "4.1" {
+		t.Errorf("matched = %+v, want [4.1]", matched)
+	}
+}
+
+func TestResolve_NaturalOrderingOfMergedDeps(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `## Epic 4: Slice 1
+
+### Story 4.1: A
+### Story 4.2: B
+### Story 4.10: J
+
+### Story 4.11: K
+
+- **Given** Story 4.2 and Story 4.10 and Story 4.1 ready
+`)
+	parsed, _ := inferdeps.ParseEpics(path)
+	sugs := inferdeps.Resolve(parsed, false)
+	var s inferdeps.Suggestion
+	for _, x := range sugs {
+		if x.StoryID == "4.11" {
+			s = x
+		}
+	}
+	merged := s.MergedDeps()
+	if len(merged) != 3 || merged[0] != "4.1" || merged[1] != "4.2" || merged[2] != "4.10" {
+		t.Errorf("merged = %v, want [4.1 4.2 4.10]", merged)
+	}
+}

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	appsprint "github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint/inferdeps"
 	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
 	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
 )
@@ -32,6 +33,7 @@ func newSprintCmd() *cobra.Command {
 		newSprintResumeCmd(),
 		newSprintStatusCmd(),
 		newSprintCacheBundleCmd(),
+		newSprintInferDepsCmd(),
 	)
 	addV6PersistentFlags(cmd)
 	return cmd
@@ -431,5 +433,89 @@ renders can find it automatically. Default output:
 	}
 	cmd.Flags().StringVar(&outPath, "out", "", "output path (default: <docs_folder>/sprint-cache-bundle.md)")
 	cmd.Flags().StringVar(&docsDir, "docs", "", "source docs folder (default: config.docs_folder)")
+	return cmd
+}
+
+// ---------- infer-deps ----------
+
+// newSprintInferDepsCmd wires `bmad sprint infer-deps` — parses an
+// epics.md file for **Given** / **Refs** / epic-level prose cues and
+// emits suggested `depends_on:` YAML patches. See issue #19.
+func newSprintInferDepsCmd() *cobra.Command {
+	var (
+		epicsPath     string
+		scope         string
+		apply         bool
+		backup        bool
+		intraEpic     bool
+	)
+	cmd := &cobra.Command{
+		Use:   "infer-deps",
+		Short: "Suggest depends_on patches by parsing epics.md prose cues (closes #19)",
+		Long: `Walks epics.md and per-story extracts dependency cues from the
+**Given** / **Refs** prose plus the parent epic header, then emits
+suggested ` + "`depends_on:`" + ` YAML patches.
+
+Dry-run (default): suggestions print to stdout — paste into epics.md.
+With ` + "`--apply`" + ` the existing depends_on line is rewritten in place;
+pair with ` + "`--backup`" + ` to keep a ` + "`.bak`" + ` companion.
+
+Recogniser confidence:
+  HIGH   explicit "Story X.Y" mention inside a **Given** / **Refs** line
+  MEDIUM "Slice <s>" or "Epic N" mention resolved to last story of that epic
+  LOW    intra-epic fallback (Story X.Y → X.(Y-1)) — only when --intra-epic`,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			// Resolve epicsPath from config.docs_folder when the flag is
+			// omitted, mirroring `bmad sprint plan`'s convention.
+			if epicsPath == "" {
+				db, err := openV6DB(ctx)
+				if err != nil {
+					return err
+				}
+				defer db.Close()
+				cfg := sqlite.NewConfigStore(db)
+				docs, err := cfg.Get(ctx, "docs_folder")
+				if err != nil {
+					return fmt.Errorf("sprint infer-deps: --epics required (docs_folder not set: %w)", err)
+				}
+				epicsPath = filepath.Join(docs, "epics.md")
+			}
+
+			res, warnings, err := inferdeps.Run(inferdeps.RunOptions{
+				EpicsPath:         epicsPath,
+				ScopeEpic:         scope,
+				Apply:             apply,
+				Backup:            backup,
+				IntraEpicFallback: intraEpic,
+			})
+			if err != nil {
+				return err
+			}
+
+			if jsonOutput {
+				args := map[string]any{
+					"epics":       epicsPath,
+					"apply":       apply,
+					"backup":      backup,
+					"intra_epic":  intraEpic,
+				}
+				if scope != "" {
+					args["scope"] = scope
+				}
+				return emitJSONStdout(commandPathSansRoot(c), args, res, warnings)
+			}
+
+			for _, w := range warnings {
+				fmt.Fprintln(os.Stderr, "warn:", w)
+			}
+			return inferdeps.EmitSummary(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&epicsPath, "epics", "", "epics.md path (default: <docs_folder>/epics.md)")
+	cmd.Flags().StringVar(&scope, "scope", "", "restrict to one epic id (e.g. 4 → only 4.* stories)")
+	cmd.Flags().BoolVar(&apply, "apply", false, "rewrite depends_on in place (default: dry-run)")
+	cmd.Flags().BoolVar(&backup, "backup", false, "write a .bak companion when --apply (no-op otherwise)")
+	cmd.Flags().BoolVar(&intraEpic, "intra-epic", false, "enable LOW-confidence Story X.Y → X.(Y-1) fallback")
 	return cmd
 }

--- a/cmd/sprint_infer_deps_test.go
+++ b/cmd/sprint_infer_deps_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestSprintInferDeps_DryRun runs the cobra command end-to-end on a small
+// synthetic epics.md fixture and asserts the stdout contains the expected
+// patch suggestion + new dep annotation.
+func TestSprintInferDeps_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	epics := filepath.Join(dir, "epics.md")
+	if err := os.WriteFile(epics, []byte(`## Epic 1: Slice 0a — Reference
+
+### Story 1.1: Pick BC
+
+### Story 1.4: Verify task check
+
+## Epic 4: Slice 1 — identity
+
+### Story 4.1: Aggregates
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+complexity: medium
+---
+
+- **Given** Story 4.1 emits events
+- **Given** Slice 0a helper available
+- **Refs:** FR-Arch-2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "infer-deps", "--epics", epics, "--no-log"})
+
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Story 4.2") {
+		t.Errorf("stdout missing Story 4.2 heading:\n%s", out)
+	}
+	if !strings.Contains(out, `depends_on: ["1.4", "4.1"]`) {
+		t.Errorf("stdout missing merged depends_on:\n%s", out)
+	}
+	if !strings.Contains(out, "+ 1.4") {
+		t.Errorf("stdout missing new-dep marker:\n%s", out)
+	}
+	if !strings.Contains(out, "agreement vs manual:") {
+		t.Errorf("stdout missing agreement-rate footer:\n%s", out)
+	}
+}
+
+func TestSprintInferDeps_Apply(t *testing.T) {
+	dir := t.TempDir()
+	epics := filepath.Join(dir, "epics.md")
+	src := `## Epic 1: Slice 0a — Reference
+
+### Story 1.4: Verify
+
+## Epic 4: Slice 1 — identity
+
+### Story 4.1: Aggregates
+
+### Story 4.2: Canonical Service
+
+---
+story_id: "4.2"
+depends_on: ["4.1"]
+---
+
+- **Given** Slice 0a helper available
+- **Refs:** FR-Arch-2
+`
+	if err := os.WriteFile(epics, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "infer-deps", "--epics", epics, "--apply", "--backup", "--no-log"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	after, err := os.ReadFile(epics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), `depends_on: ["1.4", "4.1"]`) {
+		t.Errorf("apply didn't merge:\n%s", string(after))
+	}
+
+	back, err := os.ReadFile(epics + ".bak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(back), `depends_on: ["4.1"]`) {
+		t.Errorf("backup not the original:\n%s", string(back))
+	}
+}
+
+func TestSprintInferDeps_JSONMode(t *testing.T) {
+	dir := t.TempDir()
+	epics := filepath.Join(dir, "epics.md")
+	if err := os.WriteFile(epics, []byte(`## Epic 1: Slice 0a
+
+### Story 1.1: A
+### Story 1.2: B
+
+- **Given** Story 1.1 ready
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"--json", "sprint", "infer-deps", "--epics", epics, "--no-log"})
+
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, `"schema_version": "v1"`) {
+		t.Errorf("expected v1 envelope: %s", out)
+	}
+	if !strings.Contains(out, `"command": "sprint infer-deps"`) {
+		t.Errorf("expected command name in envelope: %s", out)
+	}
+	if !strings.Contains(out, `"dep_id": "1.1"`) {
+		t.Errorf("expected inferred dep id in result: %s", out)
+	}
+}
+
+// captureStdout redirects os.Stdout through a pipe while fn runs and
+// returns whatever fn wrote to stdout. The audit-log stream-tap is
+// disabled by the caller (disableStreamTap=true) so it doesn't interpose.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	return buf.String()
+}


### PR DESCRIPTION
## Summary

Adds `bmad sprint infer-deps` — a deterministic parser for epics.md prose cues (`**Given**`, `**Refs**`, epic-level `Epic N` / `Slice <s>` mentions) that emits suggested `depends_on:` YAML patches per story. Eliminates the recurring 4–6 hour mechanical prose-to-YAML backfill (nutrition's 186-story cutover was the recurring pain point).

## Usage

```bash
# Dry-run — patches print to stdout, paste into epics.md
bmad sprint infer-deps --epics docs/features/eda-cutover/epics.md

# One epic only
bmad sprint infer-deps --epics … --scope 4

# Rewrite in place with backup
bmad sprint infer-deps --epics … --apply --backup

# Enable LOW-confidence intra-epic fallback (Story X.Y → X.(Y-1))
bmad sprint infer-deps --epics … --intra-epic

# Machine-readable v1 envelope
bmad sprint infer-deps --epics … --json
```

## Recogniser confidence

| Confidence | Cue                                                            |
| ---------- | -------------------------------------------------------------- |
| HIGH       | explicit `Story X.Y` mention inside `**Given**` / `**Refs**`   |
| MEDIUM     | `Slice <s>` / `Epic N` mention → last story of matching epic   |
| LOW        | intra-epic fallback `X.Y → X.(Y-1)` — opt-in via `--intra-epic` |

## Validation against nutrition (190 stories, all manually backfilled)

Smoke ran against `/home/alejandrososa/Documents/startup-projects/nutrition-v2-go/.worktrees/develop-active/docs/features/eda-cutover/epics.md`:

| Mode                    | Inferred | Matched manual deps | Agreement |
| ----------------------- | -------- | ------------------- | --------- |
| default (no fallback)   | 16       | 0                   | 0%        |
| `--intra-epic` enabled  | 168      | 152 (across 159 scored stories) | **90.5%** |

Interpretation:
- **Default mode** is conservative — it only fires on cross-epic Slice mentions, which the manual backfill encoded at a finer grain (e.g. "Slice 0a saveWithEvents helper" was manually encoded as → 1.2, the tool suggests → 1.4 the last story of Epic 1). The 16 "NEW" suggestions are all the valuable signal — they're cross-epic deps the manual backfill missed.
- **With `--intra-epic`**, intra-epic chains (X.Y → X.(Y-1)) drive 90.5% agreement. The 17 stories where the tool suggested deps that the manual backfill didn't include match the prompt's expected pattern: places the dev session manually relaxed for parallelism (e.g. Epic 2 batch 1).
- HIGH-disagreement on Epic 1's mandatory chain (1.1 → 1.2 → 1.3 → 1.4) did NOT occur — the tool correctly inferred those when `--intra-epic` was on.

## Technical changes

New package `application/sprint/inferdeps/`:

- `parser.go` — epics.md tokenizer: extracts `**Given**` / `**Refs**` spans + parent epic context (epic id + slice tag from the `## Epic N: Slice <s>` header). Frontmatter `depends_on:` extracted in both inline and block-list forms.
- `resolver.go` — three recognisers (story-mention, slice-mention, epic-mention) plus optional intra-epic fallback. Dedupes by (story, dep) pair, stable-sorted (HIGH > MEDIUM > LOW, natural story-id order so 4.2 < 4.10).
- `patch.go` — text-mode `EmitSummary` (annotated yaml fragment per story), `ComputeAgreement` (tool vs. manual scoring), `ApplyPatches` (in-place rewrite of inline + block-list `depends_on:` forms with optional `.bak`).
- `command.go` — `Run` function as testable pipeline seam.
- `cmd/sprint.go` — adds the `newSprintInferDepsCmd()` subcommand (registered alongside existing `plan` / `run` / `pause` / `status` / `cache-bundle`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./application/sprint/inferdeps/... ./cmd/...` clean
- [x] `go test ./application/sprint/inferdeps/... ./cmd/...` green (14 new tests covering parser, resolver, patch, command)
- [x] Smoke against nutrition's 190-story epics.md — outputs reasonable suggestions, 90.5% agreement w/ manual backfill (with `--intra-epic`)
- [x] `--json` mode emits stable v1 envelope (matches existing `cmd/jsonout.go` schema)
- [x] `--apply --backup` round-trip: in-place rewrite + `.bak` companion, preserves rest of frontmatter

Note: a pre-existing failing test (`TestBuildStoryContext_NutritionV2Go_Story49_HasCodeContext` in `application/sprint/codecontext_test.go`, introduced by #11) times out scanning the developer-machine-specific nutrition checkout — unchanged by this PR and unrelated to the new package.

Closes #19.