### PR TITLE
fix(prompts): TOKEN_BREAKDOWN reporting suffix on every L3 stage (closes #20)

### DIFF
--- a/infrastructure/prompts/renderer_test.go
+++ b/infrastructure/prompts/renderer_test.go
@@ -1,6 +1,7 @@
 package prompts_test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -434,5 +435,174 @@ func TestRender_CacheInvariance_PriorAttempt_DoesNotBustPrefix(t *testing.T) {
 	}
 	if extractStablePrefix(t, a) != extractStablePrefix(t, b) {
 		t.Fatalf("prefix changed when PriorAttempt was added — retry context must live in suffix")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TOKEN_BREAKDOWN instruction (issue #20)
+//
+// Every stage_*.tmpl must include the token-breakdown reporting partial in
+// its suffix so the L3 agent emits a parseable usage line as the last line
+// of its response. The L1 orchestrator's parser regex is the contract.
+
+// tokenBreakdownAnchor is the literal anchor the L1 orchestrator's parser
+// matches against. Must stay in sync with the partial template
+// `infrastructure/prompts/templates/token_breakdown_instruction.tmpl`.
+const tokenBreakdownAnchor = "TOKEN_BREAKDOWN: input=N output=N cache_read=N cache_create=N"
+
+// tokenBreakdownParseRegex is the exact regex shape the orchestrator parses
+// off the L3 agent's response. Matches `^TOKEN_BREAKDOWN: input=\d+ output=\d+ cache_read=\d+ cache_create=\d+`.
+// This test only validates the regex compiles + matches a synthetic line —
+// the real consumer is the orchestrator skill in nutrition develop.
+var tokenBreakdownParseRegex = regexp.MustCompile(`(?m)^TOKEN_BREAKDOWN: input=(\d+) output=(\d+) cache_read=(\d+) cache_create=(\d+)\s*$`)
+
+func TestRender_TokenBreakdownInstruction_PresentInEveryStage(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	envCommon := map[string]any{"PgPort": 7611, "RedisPort": 7612, "OtelPort": 7613, "DbName": "story_x"}
+	cases := []struct {
+		stage string
+		data  map[string]any
+	}{
+		{"stage_hydrate", map[string]any{
+			"StoryID": "1.1", "Mode": "pragmatic",
+			"EpicsPath": "/p/epics.md", "ArchitecturePath": "/p/arch.md",
+			"HydratedFile": "/p/1.1.md",
+		}},
+		{"stage_atdd", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict",
+			"EnvConfig": envCommon,
+		}},
+		{"stage_automate", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict",
+			"EnvConfig": envCommon,
+		}},
+		{"stage_implement", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic",
+			"EnvConfig": envCommon,
+		}},
+		{"stage_test_review", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "strict",
+			"EnvConfig": envCommon,
+		}},
+		{"stage_code_review", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic",
+			"Iteration": 1, "MaxIterations": 3, "EnvConfig": envCommon,
+		}},
+		{"stage_commit", map[string]any{
+			"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic",
+			"Branch": "fix/x",
+		}},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.stage, func(t *testing.T) {
+			t.Parallel()
+			out, err := r.Render(c.stage, c.data)
+			if err != nil {
+				t.Fatalf("render %s: %v", c.stage, err)
+			}
+			if !strings.Contains(out, tokenBreakdownAnchor) {
+				t.Fatalf("%s: rendered prompt missing TOKEN_BREAKDOWN instruction anchor %q\n--- output ---\n%s",
+					c.stage, tokenBreakdownAnchor, out)
+			}
+			// The instruction must live in the SUFFIX, not the PREFIX —
+			// the partial is shared text but its placement must be below
+			// the cache boundary so an unbundled prompt-cache prefix
+			// still benefits from anything above the marker.
+			if idxMarker := strings.Index(out, stageCacheBoundaryMarker); idxMarker >= 0 {
+				idxAnchor := strings.Index(out, tokenBreakdownAnchor)
+				if idxAnchor < idxMarker {
+					t.Fatalf("%s: TOKEN_BREAKDOWN anchor appears BEFORE cache boundary — instruction must be in the suffix to preserve prefix invariance",
+						c.stage)
+				}
+			}
+		})
+	}
+}
+
+func TestTokenBreakdownParseRegex_MatchesSyntheticAgentLine(t *testing.T) {
+	t.Parallel()
+	// Sanity: the regex shape the orchestrator parser uses must actually
+	// match a well-formed line. Pins the contract so a future template
+	// edit can't silently rename a field without breaking this test.
+	cases := []struct {
+		name string
+		line string
+		want [4]string // input, output, cache_read, cache_create
+	}{
+		{"happy path", "TOKEN_BREAKDOWN: input=12345 output=678 cache_read=9000 cache_create=4321", [4]string{"12345", "678", "9000", "4321"}},
+		{"all zeros", "TOKEN_BREAKDOWN: input=0 output=0 cache_read=0 cache_create=0", [4]string{"0", "0", "0", "0"}},
+		{"trailing newline", "TOKEN_BREAKDOWN: input=1 output=2 cache_read=3 cache_create=4\n", [4]string{"1", "2", "3", "4"}},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			m := tokenBreakdownParseRegex.FindStringSubmatch(c.line)
+			if m == nil {
+				t.Fatalf("no match for %q", c.line)
+			}
+			got := [4]string{m[1], m[2], m[3], m[4]}
+			if got != c.want {
+				t.Fatalf("submatch mismatch: got %v want %v", got, c.want)
+			}
+		})
+	}
+
+	// Negative cases — must NOT match.
+	neg := []string{
+		"TOKEN_BREAKDOWN: input=unknown output=0 cache_read=0 cache_create=0",
+		"TOKEN_BREAKDOWN input=1 output=2 cache_read=3 cache_create=4", // missing colon
+		"token_breakdown: input=1 output=2 cache_read=3 cache_create=4", // wrong case
+		"prefix TOKEN_BREAKDOWN: input=1 output=2 cache_read=3 cache_create=4", // not anchored start-of-line
+	}
+	for _, s := range neg {
+		if tokenBreakdownParseRegex.FindString(s) != "" {
+			t.Errorf("regex unexpectedly matched %q", s)
+		}
+	}
+}
+
+// The TOKEN_BREAKDOWN instruction adds STATIC text — it must not bust the
+// cache-invariance contract for any stage. Re-runs the cross-story prefix
+// check against a stage to confirm the partial doesn't introduce per-call
+// drift.
+func TestRender_TokenBreakdownInstruction_DoesNotBustCacheInvariance(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	for _, stage := range []string{"stage_implement", "stage_hydrate", "stage_code_review", "stage_commit"} {
+		stage := stage
+		t.Run(stage, func(t *testing.T) {
+			t.Parallel()
+			a := map[string]any{
+				"StoryID": "1.1", "HydratedFile": "/p/1.1.md", "Mode": "pragmatic",
+				"EnvConfig": map[string]any{"PgPort": 7611, "DbName": "story_a"},
+				"EpicsPath": "/p/epics.md", "ArchitecturePath": "/p/arch.md",
+				"Branch":    "fix/x", "Iteration": 1, "MaxIterations": 3,
+			}
+			b := map[string]any{
+				"StoryID": "9.9", "HydratedFile": "/q/9.9.md", "Mode": "strict",
+				"EnvConfig": map[string]any{"PgPort": 7801, "DbName": "story_b"},
+				"EpicsPath": "/q/epics.md", "ArchitecturePath": "/q/arch.md",
+				"Branch":    "fix/y", "Iteration": 2, "MaxIterations": 3,
+			}
+			ra, err := r.Render(stage, a)
+			if err != nil {
+				t.Fatalf("render A (%s): %v", stage, err)
+			}
+			rb, err := r.Render(stage, b)
+			if err != nil {
+				t.Fatalf("render B (%s): %v", stage, err)
+			}
+			if extractStablePrefix(t, ra) != extractStablePrefix(t, rb) {
+				t.Fatalf("%s: prefix diverged after TOKEN_BREAKDOWN partial was added", stage)
+			}
+			// Both renders must contain the instruction (defense-in-depth).
+			if !strings.Contains(ra, tokenBreakdownAnchor) || !strings.Contains(rb, tokenBreakdownAnchor) {
+				t.Errorf("%s: TOKEN_BREAKDOWN instruction missing from one of the renders", stage)
+			}
+		})
 	}
 }

--- a/infrastructure/prompts/templates/stage_atdd.tmpl
+++ b/infrastructure/prompts/templates/stage_atdd.tmpl
@@ -73,3 +73,5 @@ this stage; the agent decides if it applies.
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_automate.tmpl
+++ b/infrastructure/prompts/templates/stage_automate.tmpl
@@ -71,3 +71,5 @@ will route accordingly.
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_code_review.tmpl
+++ b/infrastructure/prompts/templates/stage_code_review.tmpl
@@ -85,3 +85,5 @@ blocking findings (strict) or any findings (pragmatic), emit
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_commit.tmpl
+++ b/infrastructure/prompts/templates/stage_commit.tmpl
@@ -62,3 +62,5 @@ The prior commit attempt failed CI (`task check`). The blocker(s) live
 in the previous attempt's `reason`. Fix them with a follow-up commit
 (re-run TDD as needed), then re-attempt this commit stage.
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_hydrate.tmpl
+++ b/infrastructure/prompts/templates/stage_hydrate.tmpl
@@ -141,3 +141,5 @@ sprint-wide standing corpus.
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_implement.tmpl
+++ b/infrastructure/prompts/templates/stage_implement.tmpl
@@ -117,3 +117,5 @@ already consumed this file; if you need quick reminders of the spec's
 
 {{.EpicContext}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/stage_test_review.tmpl
+++ b/infrastructure/prompts/templates/stage_test_review.tmpl
@@ -73,3 +73,5 @@ or implement (per max_qa_cycles budget). Otherwise `status: ok`.
 
 {{template "retry_context" .PriorAttempt}}
 {{- end}}
+
+{{template "token_breakdown_instruction" .}}

--- a/infrastructure/prompts/templates/token_breakdown_instruction.tmpl
+++ b/infrastructure/prompts/templates/token_breakdown_instruction.tmpl
@@ -1,0 +1,58 @@
+{{/* Slot contract: none — this partial is byte-identical across every call.
+
+       Goal: instruct the L3 stage agent to surface its own usage breakdown
+       in a single literal line that the L1 orchestrator can parse with a
+       regex. Closes bmad-cli#20 — Claude Code's Task tool result exposes
+       only `total_tokens` to the parent session; the
+       `cache_read_input_tokens` / `cache_creation_input_tokens` fields
+       needed to compute `cache_hit_rate` are not surfaced, so we route
+       them through the agent's text response instead.
+
+       Format (REGEX-anchored, must match `^TOKEN_BREAKDOWN: input=\d+ output=\d+ cache_read=\d+ cache_create=\d+`):
+
+           TOKEN_BREAKDOWN: input=N output=N cache_read=N cache_create=N
+
+       This partial is included at the SUFFIX of every stage_*.tmpl —
+       below the per-story variable content. Because the text is
+       byte-identical across every dispatch, placement does NOT bust the
+       cache-stable prefix established by Batch E.
+*/ -}}
+
+## Final reporting — emit a TOKEN_BREAKDOWN line as the very last line of your response
+
+After your usual structured JSON return (and any prose summary), the
+**final line** of your response MUST be a single literal line in this
+exact format:
+
+```
+TOKEN_BREAKDOWN: input=N output=N cache_read=N cache_create=N
+```
+
+Where each `N` is a non-negative integer drawn from your own usage
+metadata for THIS subagent invocation:
+
+- `input` — total input tokens for this call (system prompt + tool
+  defs + user message + tool results consumed during the run)
+- `output` — total output tokens you generated (assistant turns +
+  tool calls)
+- `cache_read` — input tokens served from the prompt-prefix cache
+  (i.e. `cache_read_input_tokens`)
+- `cache_create` — input tokens written to a new cache entry on this
+  call (i.e. `cache_creation_input_tokens`)
+
+If you cannot determine a specific field for this invocation, emit
+`0` for it (NOT `unknown`, NOT a placeholder) — the orchestrator's
+parser is a strict regex that expects integers. A best-effort estimate
+beats `0` when you have a signal (e.g., your context window
+introspection tools report a figure), but never invent values.
+
+The line must be the LITERAL last line — no trailing prose, no code
+fence, no markdown bullet. The orchestrator's L1 parser matches the
+anchor `^TOKEN_BREAKDOWN: input=` via regex on your response text;
+anything after that line is dropped from the dispatch record.
+
+This contract closes bmad-cli#20 (cache-hit-rate measurement gap). The
+fields feed `bmad dispatch record --input-tokens / --output-tokens /
+--cache-read-tokens / --cache-create-tokens`, which in turn feeds
+`bmad sprint status`'s `cache_hit_rate = cache_read / (input + cache_read)`
+column.


### PR DESCRIPTION
## Summary

- **Closes #20** — cache_hit_rate stayed at 0.0% across Epic 1 + Epic 2-batch-2 (5.69M cumulative input tokens, ~36 L3 dispatches) AFTER Batch E's template restructure. Diagnosis from the dev session (issue thread): Claude Code's `Task` tool result surfaces only `total_tokens` to the L1 orchestrator — the `cache_read_input_tokens` / `cache_creation_input_tokens` fields needed for `cache_hit_rate = cache_read / (input + cache_read)` are NOT exposed through the Task API to a parent skill. So `bmad dispatch record --cache-read-tokens N` (added in PR #18) had no source of `N` and the orchestrator recorded zeros every time.
- **Path chosen: option 2 (TOKEN_BREAKDOWN line workaround).** Real caching may well be happening; it was just unmeasurable from the L1 side. Option 1 (parsing fix in the orchestrator skill alone) was ruled out: the structured fields are not in the Task result to parse.
- **Fix:** every `stage_*.tmpl` now includes a shared `token_breakdown_instruction.tmpl` partial at the SUFFIX, instructing the L3 agent to end its response with a literal regex-anchored line:

      TOKEN_BREAKDOWN: input=N output=N cache_read=N cache_create=N

  The orchestrator's L1 parser will regex-match that line off the L3 agent's text response and feed the four flags to `bmad dispatch record`.
- **Cache invariance preserved.** The new bytes are identical across every dispatch of a given stage. The TOKEN_BREAKDOWN partial is included AFTER the existing `## Story dispatch` cache boundary (suffix), so Batch E's cache-stable prefix is byte-untouched. `cmd/render.go` is intentionally not modified.

## Files

- `infrastructure/prompts/templates/token_breakdown_instruction.tmpl` — new shared partial (no slots; byte-identical across dispatches)
- `infrastructure/prompts/templates/stage_{hydrate,atdd,automate,implement,test_review,code_review,commit}.tmpl` — each now ends with `{{template \"token_breakdown_instruction\" .}}` after all variable-suffix blocks
- `infrastructure/prompts/renderer_test.go` — three new tests pin the contract

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./infrastructure/prompts/... ./cmd/...` — all green (`prompts` 1.0s, `cmd` 4.5s)
- [x] `bmad render stage_hydrate --data-json '{...}'` — visually confirms the instruction renders as the last block
- [x] `TestRender_TokenBreakdownInstruction_PresentInEveryStage` — anchor present + after cache-boundary marker for all 7 stages
- [x] `TestTokenBreakdownParseRegex_MatchesSyntheticAgentLine` — orchestrator parser regex compiles + matches three happy paths, rejects four negative cases (missing colon, wrong case, prose prefix, `unknown` placeholder)
- [x] `TestRender_TokenBreakdownInstruction_DoesNotBustCacheInvariance` — same-stage cross-story prefix still byte-identical (Batch E's invariance held)

## Out of scope (deliberate)

- Touching `cmd/render.go` (Batch E ownership)
- Touching `application/sprint/planner.go` (Batch D)
- Touching `.release-please-*`
- Updating the nutrition `bmad-v6-orchestrator` SKILL.md to parse the new line — separate change on nutrition develop (the skill change can land independently of this PR once Epic 2 batch 3 picks up the new templates via `bmad render`)

## Smoke verification

A fresh L3 dispatch on Epic 2 batch 3 (whenever it's dispatched) will surface the TOKEN_BREAKDOWN line; the orchestrator skill will then start populating non-zero `--cache-read-tokens` values and `bmad sprint status` should show `cache_hit_rate > 0` for stages where the cache is genuinely warm (same agent type called repeatedly, e.g. code-review iter-1 vs iter-2).

If real caching never was happening (alternate hypothesis), the breakdown will surface zeros honestly instead of by default — which is itself a measurable improvement over the current state where zeros could mean either "no cache" or "no instrumentation."

🤖 Generated with [Claude Code](https://claude.com/claude-code)