### PR TITLE
feat(cli): --scope on `bmad story next` + `bmad story status` (closes #35)

### DIFF
--- a/application/state/story.go
+++ b/application/state/story.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	appsprint "github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
 	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
 )
 
@@ -39,7 +40,24 @@ type NextAction struct {
 //
 // File-overlap detection: a story is added to the batch only if its affects
 // set is disjoint from every story already chosen.
+//
+// Equivalent to NextWithScope(ctx, max, "").
 func (s *StoryService) Next(ctx context.Context, max int) ([]NextAction, error) {
+	return s.NextWithScope(ctx, max, "")
+}
+
+// NextWithScope is Next with an optional --scope <epic-id> per-call filter
+// (issue #35). When scope is non-empty, only stories matching the epic
+// (prefix + dot rule from appsprint.StoryMatchesEpic) are considered as
+// candidates. An empty scope is a no-op filter — behaviour identical to
+// Next. The filter is applied to the candidate set BEFORE dependency /
+// file-overlap selection, so it never mutates state and never widens the
+// returned batch beyond the scoped slice.
+//
+// A scope that matches zero stories returns an empty batch (no error).
+// That mirrors the "nothing dispatchable right now" shape callers already
+// handle for the unscoped case.
+func (s *StoryService) NextWithScope(ctx context.Context, max int, scope string) ([]NextAction, error) {
 	if max <= 0 {
 		max = s.effectiveMaxParallel(ctx)
 	}
@@ -56,6 +74,11 @@ func (s *StoryService) Next(ctx context.Context, max int) ([]NextAction, error) 
 	for _, st := range candidates {
 		if len(out) >= max {
 			break
+		}
+		// --scope filter — apply BEFORE the (more expensive) deps + affects
+		// lookups so a tightly-scoped call short-circuits cleanly.
+		if !appsprint.StoryMatchesEpic(st.ID, scope) {
+			continue
 		}
 		ok, err := s.depsSatisfied(ctx, st.ID)
 		if err != nil {

--- a/application/state/story_test.go
+++ b/application/state/story_test.go
@@ -57,6 +57,124 @@ func TestNext_RespectsDependencies(t *testing.T) {
 	}
 }
 
+// TestStoryNext_ScopeFilters seeds pending stories across 3 epics; --scope 2
+// must return only Epic 2's candidates, none from 1.* or 3.*. Issue #35.
+func TestStoryNext_ScopeFilters(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	// Three epics, two stories each — all pending, no deps, no affects.
+	for _, id := range []string{"1.1", "1.2", "2.1", "2.2", "3.1", "3.2"} {
+		seed(t, svc, id, state.StatusPending)
+	}
+
+	out, err := svc.NextWithScope(ctx, 10, "2")
+	if err != nil {
+		t.Fatalf("NextWithScope: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("NextWithScope --scope 2 len = %d, want 2 (2.1 + 2.2)", len(out))
+	}
+	for _, n := range out {
+		if n.StoryID != "2.1" && n.StoryID != "2.2" {
+			t.Fatalf("scope 2 returned out-of-scope story %q (full: %+v)", n.StoryID, out)
+		}
+	}
+}
+
+// TestStoryNext_ScopeEmpty — --scope 99 (no matching epic) is NOT an error;
+// it returns an empty batch + exit 0 (the semantic equivalent of "nothing
+// dispatchable right now in this scope"). Issue #35.
+func TestStoryNext_ScopeEmpty(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	seed(t, svc, "1.1", state.StatusPending)
+	seed(t, svc, "2.1", state.StatusPending)
+
+	out, err := svc.NextWithScope(ctx, 10, "99")
+	if err != nil {
+		t.Fatalf("NextWithScope --scope 99 (no match) errored: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("NextWithScope --scope 99 = %+v, want empty batch", out)
+	}
+}
+
+// TestStoryNext_ScopeWithMaxParallel — scope + max compose: --scope 2
+// returns only 2.* candidates, AND the max cap clamps within that subset.
+// Verifies the filter is applied BEFORE the cap (else max would be filled
+// with 1.* and then dropped, breaking the contract).
+func TestStoryNext_ScopeWithMaxParallel(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	// Epic 1 has 1 story; Epic 2 has 3 stories. Cap to 2 → expect 2 from Epic 2.
+	seed(t, svc, "1.1", state.StatusPending)
+	seed(t, svc, "2.1", state.StatusPending)
+	seed(t, svc, "2.2", state.StatusPending)
+	seed(t, svc, "2.3", state.StatusPending)
+
+	out, err := svc.NextWithScope(ctx, 2, "2")
+	if err != nil {
+		t.Fatalf("NextWithScope: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("NextWithScope --scope 2 --max 2 len = %d, want 2", len(out))
+	}
+	for _, n := range out {
+		if !(n.StoryID == "2.1" || n.StoryID == "2.2" || n.StoryID == "2.3") {
+			t.Fatalf("scope 2 returned out-of-scope story %q (full: %+v)", n.StoryID, out)
+		}
+	}
+}
+
+// TestStoryNext_ScopeOffByOne — --scope 1 must NOT match 10.* (prefix+dot
+// rule, mirroring sprint plan --scope). Guards against the "1" prefix
+// accidentally matching "10.1" via naive HasPrefix.
+func TestStoryNext_ScopeOffByOne(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	seed(t, svc, "1.1", state.StatusPending)
+	seed(t, svc, "10.1", state.StatusPending)
+
+	out, err := svc.NextWithScope(ctx, 10, "1")
+	if err != nil {
+		t.Fatalf("NextWithScope: %v", err)
+	}
+	if len(out) != 1 || out[0].StoryID != "1.1" {
+		t.Fatalf("NextWithScope --scope 1 = %+v, want only 1.1 (10.1 must NOT match)", out)
+	}
+}
+
+// TestStoryNext_EmptyScopeEquivalentToNext — sanity: an empty scope is a
+// no-op filter (verifies backward compatibility with existing svc.Next).
+func TestStoryNext_EmptyScopeEquivalentToNext(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	seed(t, svc, "1.1", state.StatusPending)
+	seed(t, svc, "2.1", state.StatusPending)
+
+	a, err := svc.Next(ctx, 10)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	b, err := svc.NextWithScope(ctx, 10, "")
+	if err != nil {
+		t.Fatalf("NextWithScope: %v", err)
+	}
+	if len(a) != len(b) {
+		t.Fatalf("Next len %d != NextWithScope(\"\") len %d", len(a), len(b))
+	}
+}
+
 func TestNext_FileOverlapPreventsParallelism(t *testing.T) {
 	t.Parallel()
 	svc, _ := newStoryService(t)

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -72,6 +72,7 @@ func newStoryStatusCmd() *cobra.Command {
 	var (
 		statusFlag string
 		stageFlag  string
+		scopeFlag  string
 		hasEnv     bool
 		hasEnvSet  bool
 	)
@@ -108,22 +109,24 @@ func newStoryStatusCmd() *cobra.Command {
 				f.HasEnv = &hasEnv
 			}
 			if jsonOutput {
-				return emitStoryListJSON(ctx, svc, c, f, statusFlag, stageFlag, hasEnvSet, hasEnv)
+				return emitStoryListJSON(ctx, svc, c, f, statusFlag, stageFlag, scopeFlag, hasEnvSet, hasEnv)
 			}
-			return printStoryTable(ctx, svc, f)
+			return printStoryTable(ctx, svc, f, scopeFlag)
 		},
 	}
 	cmd.Flags().StringVar(&statusFlag, "status", "", "filter by status")
 	cmd.Flags().StringVar(&stageFlag, "stage", "", "filter by current stage")
+	cmd.Flags().StringVar(&scopeFlag, "scope", "", "restrict rows to one epic id (e.g. 2 → only 2.* stories)")
 	cmd.Flags().BoolVar(&hasEnv, "has-env", false, "filter by env-up state")
 	return cmd
 }
 
-func printStoryTable(ctx context.Context, svc *appstate.StoryService, f state.StoryFilter) error {
+func printStoryTable(ctx context.Context, svc *appstate.StoryService, f state.StoryFilter, scope string) error {
 	rows, err := svc.Stories.List(ctx, f)
 	if err != nil {
 		return err
 	}
+	rows = filterStoriesByScope(rows, scope)
 	if len(rows) == 0 {
 		fmt.Println("(no stories match filter)")
 		return nil
@@ -143,6 +146,23 @@ func printStoryTable(ctx context.Context, svc *appstate.StoryService, f state.St
 			st.ID, st.Status, stage, st.Complexity, ci, st.Title)
 	}
 	return w.Flush()
+}
+
+// filterStoriesByScope is the `bmad story status --scope <epic>` post-filter
+// (issue #35). Empty scope is a no-op. Uses the same prefix+dot matching
+// rule as `bmad sprint plan --scope` via appsprint.StoryMatchesEpic, so
+// --scope 1 will NOT match 10.* (avoids the off-by-one prefix bug).
+func filterStoriesByScope(rows []state.Story, scope string) []state.Story {
+	if scope == "" {
+		return rows
+	}
+	out := rows[:0]
+	for _, st := range rows {
+		if appsprint.StoryMatchesEpic(st.ID, scope) {
+			out = append(out, st)
+		}
+	}
+	return out
 }
 
 func printStoryDetail(ctx context.Context, svc *appstate.StoryService, id string) error {
@@ -236,6 +256,7 @@ func newStoryNextCmd() *cobra.Command {
 		max     int
 		claim   bool
 		claimer string
+		scope   string
 	)
 	cmd := &cobra.Command{
 		Use:   "next",
@@ -252,7 +273,14 @@ non-complete story is cleared so a crashed orchestrator session doesn't
 permanently lock the story. Reaped ids print a one-line warning to
 stderr; the JSON envelope on stdout lists them in reaped_claims so
 downstream telemetry can count them. Set claim_ttl_seconds=0 in config
-to disable the reaper.`,
+to disable the reaper.
+
+--scope <epic-id> (issue #35): per-call filter that restricts the
+candidate set to stories whose id matches the epic (e.g. --scope 2 →
+only 2.* stories; --scope 10 will NOT match 1.* — uses the same
+prefix+dot rule as ` + "`bmad sprint plan --scope`" + `). The filter is
+applied to candidates BEFORE pick, never mutates state, and an empty
+match returns an empty batch (exit 0), not an error.`,
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
 			svc, cleanup, err := openStoryService(ctx)
@@ -265,6 +293,11 @@ to disable the reaper.`,
 			// becomes eligible on the same `bmad story next` invocation
 			// that exposes the gap. Operator gets a warning per reaped id —
 			// silence here would mask the orchestrator-crash residue.
+			//
+			// NOTE: reaping is intentionally global, not --scope-bounded —
+			// a stuck claim outside the requested scope is still crash
+			// residue worth clearing on the same invocation. The reaper
+			// touches claim metadata only, never story status.
 			ttl := effectiveClaimTTL(ctx, svc)
 			reaped, err := svc.Stories.ReapStaleClaims(ctx, ttl)
 			if err != nil {
@@ -276,7 +309,7 @@ to disable the reaper.`,
 					id, ttl)
 			}
 
-			actions, err := svc.Next(ctx, max)
+			actions, err := svc.NextWithScope(ctx, max, scope)
 			if err != nil {
 				return err
 			}
@@ -316,11 +349,17 @@ to disable the reaper.`,
 				"reaped_claims":     reaped,
 				"claim_ttl_seconds": ttl,
 			}
+			if scope != "" {
+				result["scope"] = scope
+			}
 			if jsonOutput {
 				args := map[string]any{
 					"max_parallel": max,
 					"claim":        claim,
 					"claimer":      claimer,
+				}
+				if scope != "" {
+					args["scope"] = scope
 				}
 				warnings := make([]string, 0, len(reaped))
 				for _, id := range reaped {
@@ -335,6 +374,7 @@ to disable the reaper.`,
 	cmd.Flags().IntVar(&max, "max-parallel", 0, "override max parallel slots (else uses config)")
 	cmd.Flags().BoolVar(&claim, "claim", true, "atomically claim returned stories (set claimed_at + claimed_by)")
 	cmd.Flags().StringVar(&claimer, "claimer", "orchestrator", "claimed_by value (e.g. session id)")
+	cmd.Flags().StringVar(&scope, "scope", "", "restrict candidates to one epic id (e.g. 2 → only 2.* stories; empty = no filter)")
 	return cmd
 }
 

--- a/cmd/story_json.go
+++ b/cmd/story_json.go
@@ -63,13 +63,14 @@ func emitStoryListJSON(
 	svc *appstate.StoryService,
 	c *cobra.Command,
 	f state.StoryFilter,
-	statusFlag, stageFlag string,
+	statusFlag, stageFlag, scopeFlag string,
 	hasEnvSet, hasEnv bool,
 ) error {
 	rows, err := svc.Stories.List(ctx, f)
 	if err != nil {
 		return err
 	}
+	rows = filterStoriesByScope(rows, scopeFlag)
 	out := make([]storyRowJSON, 0, len(rows))
 	for _, st := range rows {
 		out = append(out, storyRowJSONFrom(st))
@@ -80,6 +81,9 @@ func emitStoryListJSON(
 	}
 	if stageFlag != "" {
 		args["stage"] = stageFlag
+	}
+	if scopeFlag != "" {
+		args["scope"] = scopeFlag
 	}
 	if hasEnvSet {
 		args["has_env"] = hasEnv

--- a/cmd/story_scope_test.go
+++ b/cmd/story_scope_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+)
+
+// TestFilterStoriesByScope covers the helper backing `bmad story status
+// --scope`. Mirrors the appsprint.StoryMatchesEpic prefix+dot rule.
+func TestFilterStoriesByScope(t *testing.T) {
+	rows := []state.Story{
+		{ID: "1.1"}, {ID: "1.2"},
+		{ID: "2.1"}, {ID: "2.2"}, {ID: "2.3"},
+		{ID: "10.1"},
+	}
+
+	tests := []struct {
+		scope string
+		want  []string
+	}{
+		{"", []string{"1.1", "1.2", "2.1", "2.2", "2.3", "10.1"}},
+		{"1", []string{"1.1", "1.2"}}, // must NOT match 10.1
+		{"2", []string{"2.1", "2.2", "2.3"}},
+		{"10", []string{"10.1"}},
+		{"99", []string{}}, // no match → empty
+	}
+
+	for _, tc := range tests {
+		// filterStoriesByScope mutates its input via rows[:0] reslicing, so
+		// hand it a fresh copy per case.
+		input := make([]state.Story, len(rows))
+		copy(input, rows)
+		got := filterStoriesByScope(input, tc.scope)
+		if len(got) != len(tc.want) {
+			t.Fatalf("scope %q: len = %d, want %d (got=%+v)", tc.scope, len(got), len(tc.want), got)
+		}
+		for i, st := range got {
+			if st.ID != tc.want[i] {
+				t.Fatalf("scope %q [%d]: id = %q, want %q", tc.scope, i, st.ID, tc.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `--scope <epic-id>` to `bmad story next` and `bmad story status` for consistency with `bmad sprint plan --scope` (#18). Per-call filter, no state mutation.

- `bmad story next --scope 2` — restrict candidates to stories with id starting `2.`
- `bmad story next --scope 99` — empty batch, exit 0 (NOT an error)
- `bmad story next --scope 2 --max-parallel 4` — both flags compose; scope is applied BEFORE the cap so out-of-scope stories never consume slots
- `bmad story status --scope 2` — table + `--json` honour the same filter

Uses the same `appsprint.StoryMatchesEpic` prefix+dot matcher as `sprint plan`, so `--scope 1` correctly does NOT match `10.*` (avoids the off-by-one prefix bug).

Stale-claim reaping in `story next` stays intentionally scope-blind — a stuck claim outside the requested scope is still crash residue worth clearing on the same invocation. The reaper touches claim metadata only, never status.

## Test plan

- [x] `TestStoryNext_ScopeFilters` — 3 epics seeded, `--scope 2` returns only 2.*
- [x] `TestStoryNext_ScopeEmpty` — `--scope 99` returns empty batch, no error
- [x] `TestStoryNext_ScopeWithMaxParallel` — scope + max compose (cap clamps within filtered subset)
- [x] `TestStoryNext_ScopeOffByOne` — `--scope 1` must NOT match `10.*`
- [x] `TestStoryNext_EmptyScopeEquivalentToNext` — backward-compat sanity (existing callers unaffected)
- [x] `TestFilterStoriesByScope` (cmd) — covers the `story status` post-filter helper
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] CLI smoke: `bmad story next --help` + `bmad story status --help` both show `--scope` with the documented semantics

Pre-existing failure in `application/sprint` `TestBuildStoryContext_NutritionV2Go_Story{12,49}_HasCodeContext` is environment-bound (atlas codeindex scan of a large external repo times out at 180s) — reproduces on `origin/main` without my changes and is unrelated to this PR.

Closes #35

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>