### PR TITLE
fix(#42): treat all-zero TOKEN_BREAKDOWN as unknown, not 0% cache

### DIFF
--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -309,6 +309,10 @@ func newSprintStatusCmd() *cobra.Command {
 			}
 
 			tokens, _ := dispatches.TokenRollupSince(ctx, time.Unix(0, 0))
+			// Issue #42 (Path 3): compute cache hit rate using sentinel detection
+			// so all-zero TOKEN_BREAKDOWN rows from L3 agents are treated as
+			// "value unknown" rather than being aggregated into a false "0%".
+			cacheStats, _ := dispatches.CacheHitRateSince(ctx, time.Unix(0, 0))
 
 			unresolved, _ := checkpoints.Unresolved(ctx)
 			paused, _ := cfg.Get(ctx, sprintPausedKey)
@@ -316,23 +320,33 @@ func newSprintStatusCmd() *cobra.Command {
 
 			// Issue #15: surface the 4-axis breakdown + cache_hit_rate so
 			// downstream dashboards can see cache health at a glance.
+			// Issue #42: replace the naive cacheHitRate(tokens) call with the
+			// sentinel-aware aggregate; "unknown" when no non-zero rows exist.
+			var cacheHitRateVal any
+			if cacheStats.Unknown {
+				cacheHitRateVal = "unknown (issue #42)"
+			} else {
+				cacheHitRateVal = cacheStats.RatePercent
+			}
 			tokenBreakdown := map[string]any{
-				"input":           tokens.Input,
-				"output":          tokens.Output,
-				"cache_read":      tokens.CacheRead,
-				"cache_create":    tokens.CacheCreate,
-				"total":           tokens.Input + tokens.Output + tokens.CacheRead + tokens.CacheCreate,
-				"cache_hit_rate":  cacheHitRate(tokens),
+				"input":          tokens.Input,
+				"output":         tokens.Output,
+				"cache_read":     tokens.CacheRead,
+				"cache_create":   tokens.CacheCreate,
+				"total":          tokens.Input + tokens.Output + tokens.CacheRead + tokens.CacheCreate,
+				"cache_hit_rate": cacheHitRateVal,
+				"cache_hit_rate_rows_counted": cacheStats.RowsCounted,
+				"cache_hit_rate_rows_total":   cacheStats.RowsTotal,
 			}
 
 			report := map[string]any{
-				"mode":             mode,
-				"paused":           paused == "true",
-				"total_stories":    len(all),
-				"by_status":        counts,
-				"batches":          batchSummary,
+				"mode":                  mode,
+				"paused":                paused == "true",
+				"total_stories":         len(all),
+				"by_status":             counts,
+				"batches":               batchSummary,
 				"unresolved_checkpoint": unresolved,
-				"tokens":           tokenBreakdown,
+				"tokens":                tokenBreakdown,
 			}
 			if jsonOutput {
 				return emitJSONStdout(commandPathSansRoot(c), nil, report, nil)
@@ -340,14 +354,14 @@ func newSprintStatusCmd() *cobra.Command {
 			if raw {
 				return json.NewEncoder(os.Stdout).Encode(report)
 			}
-			return printSprintTable(report, counts, batchSummary, tokens)
+			return printSprintTable(report, counts, batchSummary, tokens, cacheStats)
 		},
 	}
 	cmd.Flags().BoolVar(&raw, "raw", false, "emit raw JSON")
 	return cmd
 }
 
-func printSprintTable(report map[string]any, counts, batches map[string]int, tokens state.TokenCounts) error {
+func printSprintTable(report map[string]any, counts, batches map[string]int, tokens state.TokenCounts, cacheStats sqlite.CacheHitRateStats) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(w, "mode\t%v\n", report["mode"])
 	fmt.Fprintf(w, "paused\t%v\n", report["paused"])
@@ -369,7 +383,15 @@ func printSprintTable(report map[string]any, counts, batches map[string]int, tok
 	fmt.Fprintf(w, "  cache read\t%d\n", tokens.CacheRead)
 	fmt.Fprintf(w, "  cache create\t%d\n", tokens.CacheCreate)
 	fmt.Fprintf(w, "  total\t%d\n", tokens.Input+tokens.Output+tokens.CacheRead+tokens.CacheCreate)
-	fmt.Fprintf(w, "  cache hit rate\t%.1f%%\n", cacheHitRate(tokens))
+	// Issue #42 (Path 3): render "unknown (issue #42)" instead of "0%" when all
+	// TOKEN_BREAKDOWN rows are all-zero (L3 agents can't introspect their usage).
+	if cacheStats.Unknown {
+		fmt.Fprintf(w, "  cache hit rate\tunknown (issue #42) — %d/%d rows have breakdown data\n",
+			cacheStats.RowsCounted, cacheStats.RowsTotal)
+	} else {
+		fmt.Fprintf(w, "  cache hit rate\t%.1f%% (%d/%d rows)\n",
+			cacheStats.RatePercent, cacheStats.RowsCounted, cacheStats.RowsTotal)
+	}
 	if cp, ok := report["unresolved_checkpoint"].(*state.Checkpoint); ok && cp != nil {
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "UNRESOLVED CHECKPOINT — run `bmad sprint resume` after deciding")

--- a/infrastructure/state/sqlite/dispatches.go
+++ b/infrastructure/state/sqlite/dispatches.go
@@ -249,3 +249,106 @@ func (s *DispatchesStore) TokenRollupForStory(ctx context.Context, storyID strin
 	}
 	return t, nil
 }
+
+// CacheHitRateStats holds the result of a per-story cache hit rate aggregate.
+// When Unknown is true, no rows had non-zero token breakdown data (issue #42,
+// Path 3: all-zero TOKEN_BREAKDOWN rows from L3 agents are treated as "value
+// unknown", not as measured 0% cache hit rate).
+type CacheHitRateStats struct {
+	StoryID     string
+	Unknown     bool    // true when no breakdown rows had non-zero data
+	RatePercent float64 // cache_read / (input + cache_read) * 100; 0 when Unknown
+	RowsCounted int     // rows with non-zero breakdown (used in rate calculation)
+	RowsTotal   int     // all dispatch rows for the story
+}
+
+// CacheHitRate computes cache_read / (input + cache_read) as a percentage for
+// the given story, skipping all-zero TOKEN_BREAKDOWN rows (issue #42).
+//
+// Sentinel detection: a row where input + output + cache_read + cache_create = 0
+// is considered "breakdown unknown" (L3 agent couldn't introspect its own usage
+// block). Such rows are excluded from both the numerator and denominator of the
+// rate, but are counted in RowsTotal so callers can see the full picture.
+//
+// Returns Unknown=true when RowsCounted=0 (no rows with measurable data).
+func (s *DispatchesStore) CacheHitRate(ctx context.Context, storyID string) (CacheHitRateStats, error) {
+	var (
+		cacheReadSum int64
+		denomSum     int64 // SUM(input_tokens + cache_read_tokens) for non-zero rows
+		rowsCounted  int
+		rowsTotal    int
+	)
+	// Use CASE WHEN inside SUM for widest SQLite compatibility, even though
+	// modernc.org/sqlite 1.50.x supports FILTER. CASE WHEN is equivalent
+	// and avoids any driver-level surprises.
+	err := s.db.sqlDB().QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN cache_read_tokens ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN input_tokens + cache_read_tokens ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN 1 ELSE 0 END), 0),
+			COUNT(*)
+		FROM dispatches
+		WHERE story_id = ?
+	`, storyID).Scan(&cacheReadSum, &denomSum, &rowsCounted, &rowsTotal)
+	if err != nil {
+		return CacheHitRateStats{}, fmt.Errorf("dispatches cache-hit-rate %q: %w", storyID, err)
+	}
+
+	stats := CacheHitRateStats{
+		StoryID:     storyID,
+		RowsCounted: rowsCounted,
+		RowsTotal:   rowsTotal,
+	}
+	if rowsCounted == 0 {
+		stats.Unknown = true
+		return stats, nil
+	}
+	if denomSum > 0 {
+		stats.RatePercent = float64(cacheReadSum) / float64(denomSum) * 100.0
+	}
+	return stats, nil
+}
+
+// CacheHitRateSince computes the sprint-level cache hit rate across all
+// dispatch rows since the given time, using the same sentinel-detection
+// logic as CacheHitRate: rows where all four token fields are zero are
+// treated as "value unknown" and excluded from the aggregate.
+func (s *DispatchesStore) CacheHitRateSince(ctx context.Context, since time.Time) (CacheHitRateStats, error) {
+	var (
+		cacheReadSum int64
+		denomSum     int64
+		rowsCounted  int
+		rowsTotal    int
+	)
+	err := s.db.sqlDB().QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN cache_read_tokens ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN input_tokens + cache_read_tokens ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) > 0
+			              THEN 1 ELSE 0 END), 0),
+			COUNT(*)
+		FROM dispatches
+		WHERE dispatched_at >= ?
+	`, since).Scan(&cacheReadSum, &denomSum, &rowsCounted, &rowsTotal)
+	if err != nil {
+		return CacheHitRateStats{}, fmt.Errorf("dispatches cache-hit-rate-since: %w", err)
+	}
+
+	stats := CacheHitRateStats{
+		RowsCounted: rowsCounted,
+		RowsTotal:   rowsTotal,
+	}
+	if rowsCounted == 0 {
+		stats.Unknown = true
+		return stats, nil
+	}
+	if denomSum > 0 {
+		stats.RatePercent = float64(cacheReadSum) / float64(denomSum) * 100.0
+	}
+	return stats, nil
+}

--- a/infrastructure/state/sqlite/dispatches_cache_test.go
+++ b/infrastructure/state/sqlite/dispatches_cache_test.go
@@ -1,0 +1,164 @@
+package sqlite_test
+
+// Tests for CacheHitRate sentinel-detection logic (issue #42, Path 3).
+//
+// L3 agents can't introspect their own API usage block, so TOKEN_BREAKDOWN
+// emits input=output=cache_read=cache_create=0 for every dispatch —
+// making an unguarded aggregate falsely report "0%" cache. These tests
+// assert that all-zero rows are treated as "value unknown, not zero."
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// TestCacheHitRate_UnknownWhenAllBreakdownsZero validates issue #42 path 3:
+// when every dispatch row for a story has input=output=cache_read=cache_create=0,
+// the aggregate cache-hit-rate query reports "unknown" (zero rows counted),
+// not "0%" (which would falsely imply we measured 0% cache).
+func TestCacheHitRate_UnknownWhenAllBreakdownsZero(t *testing.T) {
+	t.Parallel()
+	db := newTempDB(t)
+	seedStory(t, db, "z.1")
+	store := sqlite.NewDispatchesStore(db)
+	ctx := context.Background()
+
+	// Insert 3 dispatch rows that are all-zero (L3 agent sentinel pattern).
+	for i := 1; i <= 3; i++ {
+		_, err := store.Insert(ctx, state.Dispatch{
+			StoryID:    "z.1",
+			Stage:      state.StageImplement,
+			AgentRole:  "l3-agent",
+			AttemptNo:  i,
+			Status:     state.DispatchOK,
+			Tokens:     state.TokenCounts{Input: 0, Output: 0, CacheRead: 0, CacheCreate: 0},
+			DurationMS: 5_000,
+		})
+		if err != nil {
+			t.Fatalf("Insert %d: %v", i, err)
+		}
+	}
+
+	stats, err := store.CacheHitRate(ctx, "z.1")
+	if err != nil {
+		t.Fatalf("CacheHitRate: %v", err)
+	}
+	if !stats.Unknown {
+		t.Errorf("Unknown = false, want true (all-zero breakdown rows must be treated as unknown)")
+	}
+	if stats.RowsCounted != 0 {
+		t.Errorf("RowsCounted = %d, want 0", stats.RowsCounted)
+	}
+	if stats.RowsTotal != 3 {
+		t.Errorf("RowsTotal = %d, want 3", stats.RowsTotal)
+	}
+	if stats.RatePercent != 0 {
+		t.Errorf("RatePercent = %v, want 0 (undefined when Unknown=true)", stats.RatePercent)
+	}
+	if stats.StoryID != "z.1" {
+		t.Errorf("StoryID = %q, want z.1", stats.StoryID)
+	}
+}
+
+// TestCacheHitRate_RealNumbers asserts that rows with actual token data are
+// counted correctly, and that interspersed all-zero rows are excluded from
+// the rate calculation but still included in RowsTotal.
+func TestCacheHitRate_RealNumbers(t *testing.T) {
+	t.Parallel()
+	db := newTempDB(t)
+	seedStory(t, db, "z.2")
+	store := sqlite.NewDispatchesStore(db)
+	ctx := context.Background()
+
+	// Row 1: all-zero (L3 sentinel — should be excluded from rate).
+	_, err := store.Insert(ctx, state.Dispatch{
+		StoryID:   "z.2",
+		Stage:     state.StageImplement,
+		AgentRole: "l3-agent",
+		AttemptNo: 1,
+		Status:    state.DispatchOK,
+		Tokens:    state.TokenCounts{Input: 0, Output: 0, CacheRead: 0, CacheCreate: 0},
+		DurationMS: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("Insert row1: %v", err)
+	}
+
+	// Row 2: real breakdown — input=1000, cache_read=500.
+	// Rate contribution: cache_read/(input+cache_read) = 500/1500 = 33.33%
+	_, err = store.Insert(ctx, state.Dispatch{
+		StoryID:   "z.2",
+		Stage:     state.StageCodeReview,
+		AgentRole: "reviewer",
+		AttemptNo: 1,
+		Status:    state.DispatchOK,
+		Tokens:    state.TokenCounts{Input: 1000, Output: 200, CacheRead: 500, CacheCreate: 50},
+		DurationMS: 8_000,
+	})
+	if err != nil {
+		t.Fatalf("Insert row2: %v", err)
+	}
+
+	// Row 3: real breakdown — input=2000, cache_read=1000.
+	// Rate contribution: cumulative cache_read/(input+cache_read) = 1500/4500 = 33.33%
+	_, err = store.Insert(ctx, state.Dispatch{
+		StoryID:   "z.2",
+		Stage:     state.StageImplement,
+		AgentRole: "tdd-implementer",
+		AttemptNo: 2,
+		Status:    state.DispatchOK,
+		Tokens:    state.TokenCounts{Input: 2000, Output: 400, CacheRead: 1000, CacheCreate: 100},
+		DurationMS: 12_000,
+	})
+	if err != nil {
+		t.Fatalf("Insert row3: %v", err)
+	}
+
+	stats, err := store.CacheHitRate(ctx, "z.2")
+	if err != nil {
+		t.Fatalf("CacheHitRate: %v", err)
+	}
+	if stats.Unknown {
+		t.Errorf("Unknown = true, want false (2 rows have real data)")
+	}
+	if stats.RowsCounted != 2 {
+		t.Errorf("RowsCounted = %d, want 2 (1 zero row excluded)", stats.RowsCounted)
+	}
+	if stats.RowsTotal != 3 {
+		t.Errorf("RowsTotal = %d, want 3", stats.RowsTotal)
+	}
+	// cache_read_sum = 500+1000 = 1500; denom = (1000+500)+(2000+1000) = 4500
+	// rate = 1500/4500 * 100 = 33.333...%
+	wantRate := float64(1500) / float64(4500) * 100.0
+	const epsilon = 0.001
+	if stats.RatePercent < wantRate-epsilon || stats.RatePercent > wantRate+epsilon {
+		t.Errorf("RatePercent = %.4f, want ~%.4f", stats.RatePercent, wantRate)
+	}
+	if stats.StoryID != "z.2" {
+		t.Errorf("StoryID = %q, want z.2", stats.StoryID)
+	}
+}
+
+// TestCacheHitRate_EmptyStory asserts that a story with no dispatch rows at
+// all also returns Unknown=true (no data is no data).
+func TestCacheHitRate_EmptyStory(t *testing.T) {
+	t.Parallel()
+	db := newTempDB(t)
+	seedStory(t, db, "z.3")
+	store := sqlite.NewDispatchesStore(db)
+	ctx := context.Background()
+
+	stats, err := store.CacheHitRate(ctx, "z.3")
+	if err != nil {
+		t.Fatalf("CacheHitRate: %v", err)
+	}
+	if !stats.Unknown {
+		t.Errorf("Unknown = false, want true for story with no dispatch rows")
+	}
+	if stats.RowsTotal != 0 {
+		t.Errorf("RowsTotal = %d, want 0", stats.RowsTotal)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CacheHitRateStats` struct and `CacheHitRate` / `CacheHitRateSince` methods to `DispatchesStore` with sentinel-detection: rows where all four token columns sum to zero are excluded from the cache rate aggregate
- `bmad sprint status` now renders `unknown (issue #42)` instead of `0%` when no non-zero breakdown rows exist; includes row counts in both table and JSON output
- Schema untouched — existing `INTEGER NOT NULL DEFAULT 0` columns keep recording zeros, they just no longer pollute the aggregate

Implements Path 3 from the issue body: keep TOKEN_BREAKDOWN protocol, document that `cache_read=0 cache_create=0` from L3 agents is "value unknown, not zero."

## Test plan

- [x] `TestCacheHitRate_UnknownWhenAllBreakdownsZero` — 3 all-zero rows → `Unknown=true`, `RowsCounted=0`, `RowsTotal=3`
- [x] `TestCacheHitRate_RealNumbers` — 1 zero row + 2 real rows → `Unknown=false`, `RowsCounted=2`, `RowsTotal=3`, `RatePercent≈33.33%`
- [x] `TestCacheHitRate_EmptyStory` — no dispatch rows at all → `Unknown=true`
- [x] Full `./cmd/...` and `./infrastructure/state/sqlite/...` test suites pass

SQLite syntax: `CASE WHEN` inside `SUM` (vs `FILTER`) for widest compatibility with the bundled `modernc.org/sqlite`.

Closes #42.
Used by [Atlas Horizon 1 closure](https://github.com/sosalejandro/atlas/issues/39) (Task 6 / Wave 0 prereq for W2-F). Tracker: sosalejandro/atlas#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)