### PR TITLE
feat(sprint): epic-level requires_epics + DAG resolver (closes #46)

### DIFF
--- a/application/sprint/parser.go
+++ b/application/sprint/parser.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -17,17 +18,82 @@ import (
 // StoryFrontmatter mirrors the per-story yaml frontmatter inside an epics.md
 // story section. Only fields meaningful at planning time are parsed.
 type StoryFrontmatter struct {
-	StoryID         string   `yaml:"story_id"`
-	Title           string   `yaml:"title"`
-	DependsOn       []string `yaml:"depends_on"`
-	Affects         []string `yaml:"affects"`
-	ResourceBudget  *struct {
+	StoryID        string   `yaml:"story_id"`
+	Title          string   `yaml:"title"`
+	DependsOn      []string `yaml:"depends_on"`
+	Affects        []string `yaml:"affects"`
+	ResourceBudget *struct {
 		RamMB    int     `yaml:"ram_mb"`
 		CPUCores float64 `yaml:"cpu_cores"`
 	} `yaml:"resource_budget"`
 	RequiresAndroid bool   `yaml:"requires_android"`
 	Complexity      string `yaml:"complexity"`
 	StoryType       string `yaml:"story_type"` // doc | code | mixed (default: code)
+
+	// BypassEpicRequires lets a single story opt out of one or more
+	// epic-level `requires_epics:` entries inherited from its parent epic
+	// header (issue #46). Rare; documented as an escape valve, not a
+	// default. Values are epic ids (ints).
+	BypassEpicRequires []int `yaml:"bypass_epic_requires"`
+}
+
+// EpicFrontmatter is the YAML block that may appear directly under a
+// `## Epic N: <title>` header (issue #46). It declares cross-epic
+// dependencies at the epic level so every story inside the epic implicitly
+// depends on the last story of each referenced epic — no more linear-chain
+// placeholders on first-story-of-epic-N.
+//
+// All fields are optional. An epic without an EpicFrontmatter block behaves
+// exactly as it did pre-#46 (story-level `depends_on` is the only signal).
+type EpicFrontmatter struct {
+	// EpicID is the epic id. Optional; when omitted we use the integer
+	// from the `## Epic N` header. Allowing an explicit value matches the
+	// pattern story_id uses in StoryFrontmatter and is useful when an epic
+	// gets renumbered without renaming the header (rare but documented).
+	EpicID int `yaml:"epic_id"`
+
+	// RequiresEpics expands to "every story in this epic implicitly
+	// depends_on the LAST story of each referenced epic". Self-reference
+	// is silently dropped (an epic requiring itself is a no-op).
+	RequiresEpics []int `yaml:"requires_epics"`
+
+	// RequiresStories pins extra cross-cutting story ids not captured by
+	// epic-level granularity. These are added to every story in the epic.
+	RequiresStories []string `yaml:"requires_stories"`
+
+	// ProvidesToEpics is informational only — the inverse for visualization.
+	// The planner ignores it (resolver builds the inverse from requires_epics
+	// when callers need it). Kept here so authors don't get a yaml-unmarshal
+	// surprise if they put it in the file.
+	ProvidesToEpics []int `yaml:"provides_to_epics"`
+}
+
+// ParsedEpic carries the parsed `## Epic N` header + its (optional)
+// frontmatter. Stored by ParseEpicsFileFull so the planner can synthesize
+// cross-epic edges at ingest time.
+type ParsedEpic struct {
+	// EpicID is the canonical id of the epic — either from the YAML
+	// frontmatter's `epic_id:` field or the integer captured by the
+	// `## Epic N` header regex. Stored as a string to match the story-id
+	// vocabulary used everywhere downstream (so "4" not 4).
+	EpicID string
+
+	// Title is the trailing portion of the `## Epic N: <title>` line.
+	Title string
+
+	// Frontmatter is the (optional) YAML block. Zero value means "no
+	// requires_epics / no requires_stories" — the epic behaves as it did
+	// pre-#46.
+	Frontmatter EpicFrontmatter
+
+	// HasFrontmatter is true iff a YAML `---` block was parsed for the
+	// epic header. Lets the planner distinguish "operator hasn't filled
+	// this in yet" from "operator explicitly chose no cross-epic deps".
+	HasFrontmatter bool
+
+	// LineNum is the 1-based line of the `## Epic N` header — surfaced in
+	// warnings so an operator can jump straight to the offending header.
+	LineNum int
 }
 
 // ParsedStory carries the frontmatter + the file path it was sourced from.
@@ -41,80 +107,232 @@ type ParsedStory struct {
 	// are flagged false — the planner's coverage-warning surfaces these so an
 	// operator can backfill dependencies before sprinting through them.
 	HasFrontmatter bool
+
+	// EpicID is the epic the story belongs to. Captured at parse time from
+	// the most-recent `## Epic N` header in document order. Used by the
+	// planner (issue #46) to attach inherited epic-level cross-epic deps.
+	// Empty when the story precedes any epic header (defensive only —
+	// real epics.md files always lead with `## Epic 1`).
+	EpicID string
+}
+
+// ParsedEpicsFile is the full result of ParseEpicsFileFull — both the
+// epic headers and the stories they contain, in document order. The
+// planner consumes both to synthesize cross-epic edges (issue #46).
+type ParsedEpicsFile struct {
+	Epics   []ParsedEpic
+	Stories []ParsedStory
 }
 
 var (
 	// Story ID accepts any run of letters/digits/dot/dash/underscore — matches
 	// both "4.1" and "1.1.payment-method-management" and slug-style ids.
-	storyHeaderRE = regexp.MustCompile(`^###\s+Story\s+([\w.\-]+)\s*[:\-]\s*(.+)$`)
+	// The trailing `[:\-] <title>` is OPTIONAL — headers without an explicit
+	// title (e.g. mid-draft `### Story 1.1` with the title still TBD) match
+	// too. Authors editing real epics.md files routinely commit titleless
+	// stubs while shaping the dependency graph; the planner must not lose
+	// them.
+	storyHeaderRE = regexp.MustCompile(`^###\s+Story\s+([\w.\-]+)\s*(?:[:\-]\s*(.+))?$`)
+
+	// Epic ID currently restricted to a leading integer per the v6 spec
+	// (`## Epic 1`, `## Epic 13`). Allowing slugs would invalidate the
+	// "last story of epic N" ordinal computation downstream.
+	epicHeaderRE = regexp.MustCompile(`^##\s+Epic\s+(\d+)\s*[:\-]?\s*(.*)$`)
 )
 
 // ParseEpicsFile reads an epics.md file and returns every story it contains.
 //
+// Back-compat wrapper around ParseEpicsFileFull — drops the epic-header
+// metadata. Existing callers (the legacy tests + a few downstream tools)
+// that only need the story list keep working unchanged. New code (the
+// planner, issue #46) calls ParseEpicsFileFull directly to get the epic
+// frontmatter alongside.
+func ParseEpicsFile(path string) ([]ParsedStory, error) {
+	parsed, err := ParseEpicsFileFull(path)
+	if err != nil {
+		return nil, err
+	}
+	return parsed.Stories, nil
+}
+
+// ParseEpicsFileFull reads an epics.md file and returns both the parsed
+// epic headers (with their optional `requires_epics:` frontmatter, issue
+// #46) and every story it contains.
+//
 // Grammar (per the v6 spec's epics.md layout):
 //
-//   ### Story <id>: <title>
+//	## Epic N: <title>
 //
-//   ---
-//   story_id: "..."
-//   depends_on: [...]
-//   ...
-//   ---
+//	---                          (optional, issue #46)
+//	epic_id: N
+//	requires_epics: [4, 6]
+//	requires_stories: ["3.4"]
+//	---
 //
-//   (free-form body, ignored for planning)
+//	### Story <id>: <title>
 //
-// Multiple stories per file. The frontmatter is OPTIONAL — stories without it
-// are still emitted (so a freshly-drafted epic doesn't silently disappear),
-// with all dependency / affects fields empty.
-func ParseEpicsFile(path string) ([]ParsedStory, error) {
+//	---                          (existing, optional)
+//	story_id: "..."
+//	depends_on: [...]
+//	...
+//	---
+//
+//	(free-form body, ignored for planning)
+//
+// Multiple stories per file. Frontmatter (epic-level AND story-level) is
+// OPTIONAL — items without it are still emitted (so a freshly-drafted epic
+// doesn't silently disappear), with all dependency fields empty.
+func ParseEpicsFileFull(path string) (ParsedEpicsFile, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("open epics %s: %w", path, err)
+		return ParsedEpicsFile{}, fmt.Errorf("open epics %s: %w", path, err)
 	}
 	defer f.Close()
 
 	var (
-		out      []ParsedStory
-		current  *ParsedStory
-		inYAML   bool
-		yamlBuf  strings.Builder
+		out          ParsedEpicsFile
+		currentEpic  *ParsedEpic
+		currentStory *ParsedStory
+		inYAML       bool
+		yamlBuf      strings.Builder
+		// yamlOwner tracks which entity (`epic` | `story`) the in-progress
+		// YAML block belongs to. The same `---` delimiter is reused at both
+		// levels; the scanner picks the owner based on document state at the
+		// moment we entered the block.
+		yamlOwner string
+		lineNum   int
 	)
+
+	flushStory := func() error {
+		if currentStory == nil {
+			return nil
+		}
+		if yamlOwner == "story" && yamlBuf.Len() > 0 {
+			if err := commitStoryYAML(currentStory, &yamlBuf); err != nil {
+				return err
+			}
+		}
+		// Inherit parent epic id for the planner's cross-epic resolver.
+		if currentEpic != nil {
+			currentStory.EpicID = currentEpic.EpicID
+		}
+		out.Stories = append(out.Stories, *currentStory)
+		currentStory = nil
+		yamlBuf.Reset()
+		yamlOwner = ""
+		inYAML = false
+		return nil
+	}
+
+	flushEpic := func() error {
+		// Closing an epic also closes its open story (defensive — well-formed
+		// epics.md files always have a Story between two `## Epic` headers).
+		if err := flushStory(); err != nil {
+			return err
+		}
+		if currentEpic == nil {
+			return nil
+		}
+		if yamlOwner == "epic" && yamlBuf.Len() > 0 {
+			if err := commitEpicYAML(currentEpic, &yamlBuf); err != nil {
+				return err
+			}
+		}
+		out.Epics = append(out.Epics, *currentEpic)
+		currentEpic = nil
+		yamlBuf.Reset()
+		yamlOwner = ""
+		inYAML = false
+		return nil
+	}
 
 	scan := bufio.NewScanner(f)
 	scan.Buffer(make([]byte, 1<<20), 1<<20) // allow long lines
 	for scan.Scan() {
+		lineNum++
 		line := scan.Text()
 
-		if m := storyHeaderRE.FindStringSubmatch(line); m != nil {
-			// Close any in-progress yaml block from a malformed prior story.
-			if current != nil {
-				if err := commit(current, &yamlBuf); err != nil {
-					return nil, err
-				}
-				out = append(out, *current)
+		if m := epicHeaderRE.FindStringSubmatch(line); m != nil {
+			if err := flushEpic(); err != nil {
+				return ParsedEpicsFile{}, fmt.Errorf("parse %s: %w", path, err)
 			}
-			current = &ParsedStory{
-				SourceFile: path,
-				StoryTitle: strings.TrimSpace(m[2]),
+			currentEpic = &ParsedEpic{
+				EpicID:  m[1],
+				Title:   strings.TrimSpace(m[2]),
+				LineNum: lineNum,
+			}
+			// Reset YAML state — a `---` block following the epic header
+			// belongs to the epic, not to any prior story.
+			inYAML = false
+			yamlBuf.Reset()
+			yamlOwner = ""
+			continue
+		}
+
+		if m := storyHeaderRE.FindStringSubmatch(line); m != nil {
+			// A story header closes any in-progress story (and any open epic
+			// YAML block that never got a closing `---` — defensive).
+			if err := flushStory(); err != nil {
+				return ParsedEpicsFile{}, fmt.Errorf("parse %s: %w", path, err)
+			}
+			// If we were mid-way through an epic YAML block when the story
+			// header arrived, commit it now — story body takes precedence.
+			if yamlOwner == "epic" && yamlBuf.Len() > 0 && currentEpic != nil {
+				if err := commitEpicYAML(currentEpic, &yamlBuf); err != nil {
+					return ParsedEpicsFile{}, fmt.Errorf("parse %s epic %s: %w", path, currentEpic.EpicID, err)
+				}
+				yamlBuf.Reset()
+				yamlOwner = ""
+				inYAML = false
+			}
+			currentStory = &ParsedStory{
+				SourceFile:  path,
+				StoryTitle:  strings.TrimSpace(m[2]),
 				Frontmatter: StoryFrontmatter{StoryID: m[1], Title: strings.TrimSpace(m[2])},
 			}
 			inYAML = false
 			yamlBuf.Reset()
+			yamlOwner = ""
 			continue
 		}
 
-		if current == nil {
-			continue // skip preamble
-		}
-
-		switch strings.TrimSpace(line) {
-		case "---":
-			inYAML = !inYAML
+		// `---` is a YAML fence. Ownership picks who's currently open:
+		// a fresh `---` after `## Epic` (and BEFORE any `### Story`)
+		// belongs to the epic. A `---` after `### Story` belongs to the
+		// story.
+		if strings.TrimSpace(line) == "---" {
 			if !inYAML {
-				if err := commit(current, &yamlBuf); err != nil {
-					return nil, fmt.Errorf("parse %s story %s: %w", path, current.Frontmatter.StoryID, err)
+				// Entering YAML. Pick the owner based on document state.
+				if currentStory != nil {
+					yamlOwner = "story"
+				} else if currentEpic != nil {
+					yamlOwner = "epic"
+				} else {
+					// Free-floating `---` before any header — treat as
+					// no-op (covers the markdown title-front-matter pattern
+					// some authors keep at the very top of the file).
+					continue
+				}
+				inYAML = true
+			} else {
+				// Exiting YAML. Commit the buffer to whoever owns it.
+				switch yamlOwner {
+				case "story":
+					if currentStory != nil {
+						if err := commitStoryYAML(currentStory, &yamlBuf); err != nil {
+							return ParsedEpicsFile{}, fmt.Errorf("parse %s story %s: %w", path, currentStory.Frontmatter.StoryID, err)
+						}
+					}
+				case "epic":
+					if currentEpic != nil {
+						if err := commitEpicYAML(currentEpic, &yamlBuf); err != nil {
+							return ParsedEpicsFile{}, fmt.Errorf("parse %s epic %s: %w", path, currentEpic.EpicID, err)
+						}
+					}
 				}
 				yamlBuf.Reset()
+				yamlOwner = ""
+				inYAML = false
 			}
 			continue
 		}
@@ -125,18 +343,18 @@ func ParseEpicsFile(path string) ([]ParsedStory, error) {
 		}
 	}
 	if err := scan.Err(); err != nil {
-		return nil, fmt.Errorf("scan %s: %w", path, err)
+		return ParsedEpicsFile{}, fmt.Errorf("scan %s: %w", path, err)
 	}
-	if current != nil {
-		// EOF — close last open story (even without trailing yaml).
-		out = append(out, *current)
+	// EOF — close any in-flight story/epic.
+	if err := flushEpic(); err != nil {
+		return ParsedEpicsFile{}, fmt.Errorf("parse %s: %w", path, err)
 	}
 
 	return out, nil
 }
 
-// commit merges any buffered yaml into the current story's frontmatter.
-func commit(s *ParsedStory, buf *strings.Builder) error {
+// commitStoryYAML merges any buffered yaml into the current story's frontmatter.
+func commitStoryYAML(s *ParsedStory, buf *strings.Builder) error {
 	if buf.Len() == 0 {
 		return nil
 	}
@@ -153,6 +371,29 @@ func commit(s *ParsedStory, buf *strings.Builder) error {
 	}
 	s.Frontmatter = fm
 	s.HasFrontmatter = true
+	return nil
+}
+
+// commitEpicYAML merges any buffered yaml into the current epic header.
+// Empty buffer is a no-op (the parser may flush a zero-length block when
+// the epic has the `---\n---` shell but no body — we treat that as "no
+// frontmatter", same as for stories).
+func commitEpicYAML(e *ParsedEpic, buf *strings.Builder) error {
+	if buf.Len() == 0 {
+		return nil
+	}
+	var fm EpicFrontmatter
+	if err := yaml.Unmarshal([]byte(buf.String()), &fm); err != nil {
+		return fmt.Errorf("yaml parse: %w", err)
+	}
+	// If frontmatter omitted epic_id, fall back to the header-derived value.
+	if fm.EpicID == 0 {
+		if n, err := strconv.Atoi(e.EpicID); err == nil {
+			fm.EpicID = n
+		}
+	}
+	e.Frontmatter = fm
+	e.HasFrontmatter = true
 	return nil
 }
 

--- a/application/sprint/planner.go
+++ b/application/sprint/planner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
 )
@@ -25,27 +26,37 @@ type Planner struct {
 
 // IngestResult summarises a Plan call.
 type IngestResult struct {
-	StoriesInserted    int     `json:"stories_inserted"`
-	StoriesUpdated     int     `json:"stories_updated"`
-	DependenciesAdded  int     `json:"dependencies_added"`
+	StoriesInserted   int `json:"stories_inserted"`
+	StoriesUpdated    int `json:"stories_updated"`
+	DependenciesAdded int `json:"dependencies_added"`
 	// DependenciesCleared counts story_dependencies rows wiped by the
 	// idempotent re-ingest step (one count per story whose old edges were
 	// dropped before its current frontmatter was re-applied). Surfaces
 	// "11 stories had their deps relaxed and reset on this replan" so an
 	// operator can see what changed.
-	DependenciesCleared int     `json:"dependencies_cleared,omitempty"`
-	AffectsAdded       int     `json:"affects_added"`
+	DependenciesCleared int `json:"dependencies_cleared,omitempty"`
+	// SynthesizedDependenciesAdded counts edges added by the issue #46
+	// cross-epic resolver (i.e. `requires_epics:` / `requires_stories:`
+	// expansion) — DependenciesAdded covers them too, but operators
+	// running side-by-side migrations want to know how many edges came
+	// from the epic-level synthesis vs. story-level `depends_on:`.
+	SynthesizedDependenciesAdded int `json:"synthesized_dependencies_added,omitempty"`
+	AffectsAdded                 int `json:"affects_added"`
 	// AffectsCleared counts story_affects rows wiped during idempotent
 	// re-ingest (analogous to DependenciesCleared).
-	AffectsCleared     int     `json:"affects_cleared,omitempty"`
-	BatchesCreated     int     `json:"batches_created"`
-	BatchIDs           []int64 `json:"batch_ids"`
+	AffectsCleared int     `json:"affects_cleared,omitempty"`
+	BatchesCreated int     `json:"batches_created"`
+	BatchIDs       []int64 `json:"batch_ids"`
 	// Scope, when non-empty, is the epic-id filter that was applied. Stories
 	// outside this scope were skipped entirely.
-	Scope              string  `json:"scope,omitempty"`
+	Scope string `json:"scope,omitempty"`
 	// StoriesSkippedByScope counts how many parsed stories were excluded
 	// because they don't belong to the requested --scope.
 	StoriesSkippedByScope int `json:"stories_skipped_by_scope,omitempty"`
+	// Warnings surfaces non-fatal diagnostics from the issue #46 resolver
+	// (placeholder-linear-chain smell, references to non-existent epics,
+	// etc.). Empty when the plan was clean.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // CoverageReport summarises frontmatter coverage of a parsed epics set —
@@ -93,21 +104,91 @@ func FilterByScope(parsed []ParsedStory, epicID string) []ParsedStory {
 // Plan persists parsed stories + builds batches. Clears any existing planned
 // batches first (re-planning replaces the queue).
 //
+// Equivalent to PlanWithEpics(ctx, nil, parsed, maxParallel) — the legacy
+// entry point for callers that don't carry epic-header metadata. The CLI
+// (cmd/sprint.go) uses PlanWithEpics so the issue #46 cross-epic resolver
+// fires; this wrapper keeps the older test suite + downstream packages
+// working without churn.
+func (p *Planner) Plan(ctx context.Context, parsed []ParsedStory, maxParallel int) (*IngestResult, error) {
+	return p.PlanWithEpics(ctx, nil, parsed, maxParallel)
+}
+
+// PlanWithEpics is the issue #46 entry point: persists parsed stories +
+// builds batches, AND expands epic-level `requires_epics:` /
+// `requires_stories:` frontmatter into synthesized story-level edges
+// before topo sorting.
+//
 // Idempotency contract (issue #21 gap 1): for every story in the parsed
 // slice, the planner FIRST wipes its existing story_dependencies and
 // story_affects rows, then re-inserts whatever the current frontmatter
-// declares. This is what makes "operator relaxed depends_on: ["1.4"] → []
-// and re-ran sprint plan" actually free the story for dispatch — without
-// the wipe, the stale edge persists in SQLite and `bmad story next` keeps
-// seeing the unmet prerequisite. Stories ABSENT from `parsed` are left
-// alone (a scoped replan never touches out-of-scope rows).
-func (p *Planner) Plan(ctx context.Context, parsed []ParsedStory, maxParallel int) (*IngestResult, error) {
+// declares (PLUS the synthesized cross-epic edges). This is what makes
+// "operator relaxed depends_on: ["1.4"] → [] and re-ran sprint plan"
+// actually free the story for dispatch — without the wipe, the stale
+// edge persists in SQLite and `bmad story next` keeps seeing the unmet
+// prerequisite. Stories ABSENT from `parsed` are left alone (a scoped
+// replan never touches out-of-scope rows).
+//
+// Cycle detection: when `epics` declares a `requires_epics:` cycle (e.g.
+// A→B and B→A), the function returns a non-nil error WITHOUT touching
+// SQLite. Story-level cycles continue to be caught by the topo-sort
+// drain check in buildBatches.
+func (p *Planner) PlanWithEpics(ctx context.Context, epics []ParsedEpic, parsed []ParsedStory, maxParallel int) (*IngestResult, error) {
 	if maxParallel <= 0 {
 		maxParallel = 4
 	}
 	res := &IngestResult{}
 
-	for _, ps := range parsed {
+	// Up-front epic-cycle check — fail fast before any SQLite mutation
+	// (acceptance criterion #4). Story-level cycles surface in the
+	// topo-sort drain check below.
+	if cycle := DetectRequiresEpicsCycle(epics); len(cycle) > 0 {
+		return nil, fmt.Errorf("planner: requires_epics cycle detected: %s", strings.Join(cycle, " -> "))
+	}
+
+	// Synthesise cross-epic deps (issue #46). Pure function — works on a
+	// copy of the parsed stories so we can layer it onto each ps.DependsOn
+	// without mutating the caller's slice. Warnings flow back through the
+	// IngestResult so the CLI can print them after success.
+	synth := SynthesizeRequiresEpics(epics, parsed)
+	res.Warnings = append(res.Warnings, synth.Warnings...)
+	res.Warnings = append(res.Warnings, DetectLinearChainPlaceholderSmell(epics, parsed)...)
+
+	// Apply synthesised deps to a working copy so downstream batching
+	// sees the unified depends_on list. We don't mutate the caller's
+	// slice — keep the parser-side ParsedStory shape pristine for any
+	// other consumer of the same `parsed` value (e.g. JSON marshalling).
+	working := make([]ParsedStory, len(parsed))
+	copy(working, parsed)
+	for i := range working {
+		extra := synth.SynthesizedDeps[working[i].Frontmatter.StoryID]
+		if len(extra) == 0 {
+			continue
+		}
+		// Combine, de-dup against own deps. `additional` keeps only the
+		// NEW edges so we can count them honestly in the IngestResult.
+		seen := make(map[string]struct{}, len(working[i].Frontmatter.DependsOn))
+		for _, d := range working[i].Frontmatter.DependsOn {
+			seen[d] = struct{}{}
+		}
+		var additional []string
+		for _, e := range extra {
+			if _, ok := seen[e]; ok {
+				continue
+			}
+			seen[e] = struct{}{}
+			additional = append(additional, e)
+		}
+		if len(additional) == 0 {
+			continue
+		}
+		combined := make([]string, 0, len(working[i].Frontmatter.DependsOn)+len(additional))
+		combined = append(combined, working[i].Frontmatter.DependsOn...)
+		combined = append(combined, additional...)
+		working[i].Frontmatter.DependsOn = combined
+		res.SynthesizedDependenciesAdded += len(additional)
+	}
+
+	for _, ps := range working {
 		st := ps.ToStory()
 		if err := p.Stories.Insert(ctx, st); err != nil {
 			// Already exists → update fields except status (preserve runtime progress).
@@ -178,7 +259,7 @@ func (p *Planner) Plan(ctx context.Context, parsed []ParsedStory, maxParallel in
 	if err := p.Batches.ClearPlan(ctx); err != nil {
 		return nil, fmt.Errorf("planner clear: %w", err)
 	}
-	batches, err := p.buildBatches(ctx, parsed, maxParallel)
+	batches, err := p.buildBatches(ctx, working, maxParallel)
 	if err != nil {
 		return nil, err
 	}

--- a/application/sprint/requires.go
+++ b/application/sprint/requires.go
@@ -1,0 +1,397 @@
+package sprint
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SynthesisResult captures the planner-side outcome of expanding
+// epic-level `requires_epics:` / `requires_stories:` into per-story
+// dependency edges (issue #46).
+type SynthesisResult struct {
+	// SynthesizedDeps maps storyID → the cross-epic edges synthesized
+	// for it. These are ADDITIVE to whatever the story's own
+	// `depends_on:` declared. Stories whose epic has no
+	// `requires_epics:` / `requires_stories:` (and that didn't opt out
+	// via story-level `bypass_epic_requires:`) get an empty slice.
+	//
+	// The slice is de-duplicated against the story's own DependsOn, so
+	// `len(SynthesizedDeps[id])` is the count of NEW edges only — not
+	// the total deps of that story.
+	SynthesizedDeps map[string][]string
+
+	// Warnings collects non-fatal diagnostics the planner should
+	// surface to the operator (placeholder linear-chain smell, missing
+	// referenced epics, etc.). Empty when the input was clean.
+	Warnings []string
+}
+
+// SynthesizeRequiresEpics walks every epic + its stories and computes the
+// `requires_epics:` / `requires_stories:` expansion. Pure function — no
+// IO, no logging, no side effects. The planner persists the result.
+//
+// Semantics (per issue #46):
+//
+//  1. For each epic E with non-empty RequiresEpics:
+//     every story S in E implicitly depends_on the last story of each
+//     epic R in E.RequiresEpics (R != E.EpicID). "Last story" = the
+//     story in epic R with the highest natural-ordinal id in document
+//     order (e.g. "4.10" > "4.2", not lex-sort).
+//
+//  2. For each epic E with non-empty RequiresStories:
+//     every story S in E implicitly depends_on each listed story id —
+//     verbatim, regardless of which epic owns it.
+//
+//  3. Story-level overrides are ADDITIVE only. The single way to suppress
+//     an epic-level requirement for a specific story is to list the
+//     unwanted epic id in that story's `bypass_epic_requires:` slice.
+//
+//  4. Self-reference (epic E requiring its own id) is silently dropped.
+//
+//  5. References to non-existent epics / stories produce a warning but
+//     do NOT fail synthesis — the planner already tolerates dangling
+//     `depends_on:` entries (treated as "external prerequisite, done
+//     elsewhere"). Surface them so an operator can decide whether
+//     they're typos.
+func SynthesizeRequiresEpics(epics []ParsedEpic, stories []ParsedStory) SynthesisResult {
+	res := SynthesisResult{
+		SynthesizedDeps: make(map[string][]string, len(stories)),
+	}
+
+	// Index: epic id → its parsed header (so we can look up RequiresEpics
+	// at synthesis time). Built first so warnings for unknown referenced
+	// epics fire even when no story in this file lives in that epic.
+	epicByID := make(map[string]ParsedEpic, len(epics))
+	for _, e := range epics {
+		epicByID[e.EpicID] = e
+	}
+
+	// Index: epic id → its stories, in document order. The planner needs
+	// "last story of epic R" — defined as the story with the highest
+	// natural-ordinal id within R (so "4.10" wins over "4.2", not the
+	// other way around as plain string-sort would say).
+	storiesByEpic := make(map[string][]ParsedStory, len(epics))
+	allStoryIDs := make(map[string]struct{}, len(stories))
+	for _, s := range stories {
+		ep := s.EpicID
+		if ep == "" {
+			ep = EpicIDFromStory(s.Frontmatter.StoryID)
+		}
+		storiesByEpic[ep] = append(storiesByEpic[ep], s)
+		allStoryIDs[s.Frontmatter.StoryID] = struct{}{}
+	}
+
+	// Last-story lookup. Sort each epic's story slice by natural ordinal
+	// once and grab the tail. Documenting the ordering is critical because
+	// "highest ordinal" is the user-visible contract.
+	lastStoryOfEpic := make(map[string]string, len(storiesByEpic))
+	for ep, ss := range storiesByEpic {
+		sorted := make([]ParsedStory, len(ss))
+		copy(sorted, ss)
+		sort.Slice(sorted, func(i, j int) bool {
+			return naturalLess(sorted[i].Frontmatter.StoryID, sorted[j].Frontmatter.StoryID)
+		})
+		lastStoryOfEpic[ep] = sorted[len(sorted)-1].Frontmatter.StoryID
+	}
+
+	// Synthesise per story.
+	for _, s := range stories {
+		ep := s.EpicID
+		if ep == "" {
+			ep = EpicIDFromStory(s.Frontmatter.StoryID)
+		}
+		owner, ok := epicByID[ep]
+		if !ok {
+			// Story is orphaned — no parent epic header captured. Common
+			// when a freshly-drafted epics.md skips the `## Epic N` line.
+			// Skip synthesis (story-level deps still apply).
+			continue
+		}
+		// `bypass_epic_requires:` is story-level — turn into a set for O(1)
+		// containment checks.
+		bypass := make(map[int]struct{}, len(s.Frontmatter.BypassEpicRequires))
+		for _, b := range s.Frontmatter.BypassEpicRequires {
+			bypass[b] = struct{}{}
+		}
+
+		// Track edges we've already added for this story, including the
+		// story's own declared deps — so synthesized output never duplicates
+		// what the author already wrote. The planner-side wipe-then-replace
+		// loop would handle dupes anyway, but de-duping here keeps the
+		// surfaced "N synthesized" count honest.
+		seen := make(map[string]struct{}, len(s.Frontmatter.DependsOn)+4)
+		seen[s.Frontmatter.StoryID] = struct{}{} // never self-depend
+		for _, d := range s.Frontmatter.DependsOn {
+			if d != "" {
+				seen[d] = struct{}{}
+			}
+		}
+
+		var synth []string
+
+		// (a) requires_epics expansion: last story of each referenced epic
+		for _, ref := range owner.Frontmatter.RequiresEpics {
+			refStr := strconv.Itoa(ref)
+			if refStr == ep {
+				continue // self-reference, silently dropped
+			}
+			if _, exists := bypass[ref]; exists {
+				continue
+			}
+			last, found := lastStoryOfEpic[refStr]
+			if !found {
+				// Referenced epic has no stories in this file — record a
+				// warning and skip. A real referenced epic with zero
+				// stories is almost certainly a misnumbering.
+				res.Warnings = append(res.Warnings, fmt.Sprintf(
+					"epic %s requires_epics: [%d] — referenced epic has no stories in this epics.md",
+					ep, ref))
+				continue
+			}
+			if _, dup := seen[last]; dup {
+				continue
+			}
+			seen[last] = struct{}{}
+			synth = append(synth, last)
+		}
+
+		// (b) requires_stories expansion: literal cross-cutting pins
+		for _, pin := range owner.Frontmatter.RequiresStories {
+			if pin == "" {
+				continue
+			}
+			if _, exists := allStoryIDs[pin]; !exists {
+				res.Warnings = append(res.Warnings, fmt.Sprintf(
+					"epic %s requires_stories: [%q] — referenced story not present in this epics.md",
+					ep, pin))
+				// Still add the edge — the planner tolerates external
+				// prerequisites. This matches existing `depends_on:` handling.
+			}
+			if _, dup := seen[pin]; dup {
+				continue
+			}
+			seen[pin] = struct{}{}
+			synth = append(synth, pin)
+		}
+
+		if len(synth) > 0 {
+			// Deterministic order: natural-id ascending so test fixtures
+			// don't flap on map-iteration randomness.
+			sort.Slice(synth, func(i, j int) bool { return naturalLess(synth[i], synth[j]) })
+			res.SynthesizedDeps[s.Frontmatter.StoryID] = synth
+		}
+	}
+
+	return res
+}
+
+// DetectRequiresEpicsCycle walks the epic-level requires_epics graph
+// looking for cycles (A.requires_epics: [B] + B.requires_epics: [A] —
+// acceptance criterion #4 of issue #46). Returns the cycle as a slice of
+// epic ids in traversal order when found, or an empty slice when the
+// graph is acyclic. Pure function.
+//
+// We only check the epic-level graph because story-level cycles (a story
+// in epic A explicitly depending on a story in epic B that already
+// requires epic A) are detected later by the topo-sort layer in
+// buildBatches — the planner already exits with "no progress" when the
+// in-degree map can't drain. The epic-level check is the cheap up-front
+// guard.
+func DetectRequiresEpicsCycle(epics []ParsedEpic) []string {
+	// Build adjacency: epic id → epics it requires (as strings, stripping
+	// self-loops because those are silently dropped at synthesis time).
+	adj := make(map[string][]string, len(epics))
+	known := make(map[string]struct{}, len(epics))
+	for _, e := range epics {
+		known[e.EpicID] = struct{}{}
+	}
+	for _, e := range epics {
+		for _, r := range e.Frontmatter.RequiresEpics {
+			refStr := strconv.Itoa(r)
+			if refStr == e.EpicID {
+				continue
+			}
+			if _, ok := known[refStr]; !ok {
+				// Referenced epic isn't in the file — can't form a cycle
+				// without both endpoints present. Synthesis-time warning
+				// surfaces this separately.
+				continue
+			}
+			adj[e.EpicID] = append(adj[e.EpicID], refStr)
+		}
+	}
+
+	const (
+		white = 0 // unvisited
+		gray  = 1 // in current DFS stack
+		black = 2 // fully explored
+	)
+	color := make(map[string]int, len(epics))
+	var (
+		stack []string
+		cycle []string
+	)
+
+	var dfs func(n string) bool
+	dfs = func(n string) bool {
+		color[n] = gray
+		stack = append(stack, n)
+		for _, m := range adj[n] {
+			switch color[m] {
+			case white:
+				if dfs(m) {
+					return true
+				}
+			case gray:
+				// Found back-edge — extract the cycle from the DFS stack.
+				for i, v := range stack {
+					if v == m {
+						cycle = append([]string(nil), stack[i:]...)
+						cycle = append(cycle, m) // close the loop visually
+						return true
+					}
+				}
+				cycle = []string{m, n, m}
+				return true
+			}
+		}
+		stack = stack[:len(stack)-1]
+		color[n] = black
+		return false
+	}
+
+	// Iterate epics in document order so the surfaced cycle is the
+	// first one a left-to-right reader would hit.
+	for _, e := range epics {
+		if color[e.EpicID] == white {
+			stack = stack[:0]
+			if dfs(e.EpicID) {
+				return cycle
+			}
+		}
+	}
+	return nil
+}
+
+// DetectLinearChainPlaceholderSmell scans for the "first story of Epic N
+// depends_on last story of Epic N-1, with NO requires_epics: declared"
+// pattern (acceptance criterion #5 of issue #46). It's the canonical
+// shape of a conservative placeholder dependency authors add when they're
+// unsure if there's a real cross-epic ordering — and the one the EDA
+// cutover wasted two days untangling. Surfacing it as a warning lets the
+// operator decide if it's a real prereq or a placeholder ready to drop.
+//
+// Returns one human-readable warning string per smelled story (empty
+// slice when nothing matches). Pure function.
+func DetectLinearChainPlaceholderSmell(epics []ParsedEpic, stories []ParsedStory) []string {
+	if len(epics) < 2 {
+		return nil
+	}
+
+	// Index epics by id + by document order. We need both: (a) is this
+	// epic the immediate successor of the one its first story depends on?
+	// (b) does this epic declare `requires_epics:` — if so, suppress the
+	// warning since the author has explicitly opted in.
+	epicByID := make(map[string]ParsedEpic, len(epics))
+	for _, e := range epics {
+		epicByID[e.EpicID] = e
+	}
+
+	// Index stories per epic in natural-id order, so we can identify
+	// "first" deterministically.
+	storiesByEpic := make(map[string][]ParsedStory, len(epics))
+	for _, s := range stories {
+		ep := s.EpicID
+		if ep == "" {
+			ep = EpicIDFromStory(s.Frontmatter.StoryID)
+		}
+		storiesByEpic[ep] = append(storiesByEpic[ep], s)
+	}
+	for ep, ss := range storiesByEpic {
+		sort.Slice(ss, func(i, j int) bool {
+			return naturalLess(ss[i].Frontmatter.StoryID, ss[j].Frontmatter.StoryID)
+		})
+		storiesByEpic[ep] = ss
+	}
+
+	lastStoryOfEpic := make(map[string]string, len(storiesByEpic))
+	for ep, ss := range storiesByEpic {
+		lastStoryOfEpic[ep] = ss[len(ss)-1].Frontmatter.StoryID
+	}
+
+	var warnings []string
+	for i := 1; i < len(epics); i++ {
+		cur := epics[i]
+		prev := epics[i-1]
+		// Skip when the current epic has already opted in to epic-level
+		// dependencies — author is being explicit, no smell.
+		if len(cur.Frontmatter.RequiresEpics) > 0 || len(cur.Frontmatter.RequiresStories) > 0 {
+			continue
+		}
+		// Need a previous epic with at least one story (to be the
+		// "last story" target) and a current epic with a first story.
+		prevLast, hasPrev := lastStoryOfEpic[prev.EpicID]
+		if !hasPrev {
+			continue
+		}
+		curStories := storiesByEpic[cur.EpicID]
+		if len(curStories) == 0 {
+			continue
+		}
+		first := curStories[0]
+		// First story explicitly depends on the previous epic's last
+		// story → looks like a placeholder.
+		for _, dep := range first.Frontmatter.DependsOn {
+			if dep == prevLast {
+				warnings = append(warnings, fmt.Sprintf(
+					"epic %s: story %s depends_on %s (last story of epic %s) but epic %s declares no requires_epics: — likely a placeholder linear chain (issue #46)",
+					cur.EpicID, first.Frontmatter.StoryID, prevLast, prev.EpicID, cur.EpicID))
+				break
+			}
+		}
+	}
+	return warnings
+}
+
+// naturalLess compares two story-id strings as humans expect:
+//
+//	"4.2"  <  "4.10"      (numeric within each dot segment)
+//	"4.1.payment" < "4.2" (segment-wise, falls back to string compare on
+//	                       non-numeric segments)
+//
+// Mirrors inferdeps.naturalLess but kept local to keep package
+// dependencies acyclic.
+func naturalLess(a, b string) bool {
+	pa := strings.Split(a, ".")
+	pb := strings.Split(b, ".")
+	for i := 0; i < len(pa) && i < len(pb); i++ {
+		ad := isAllDigits(pa[i])
+		bd := isAllDigits(pb[i])
+		if ad && bd {
+			ai, _ := strconv.Atoi(pa[i])
+			bi, _ := strconv.Atoi(pb[i])
+			if ai != bi {
+				return ai < bi
+			}
+			continue
+		}
+		if pa[i] != pb[i] {
+			return pa[i] < pb[i]
+		}
+	}
+	return len(pa) < len(pb)
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/application/sprint/requires_test.go
+++ b/application/sprint/requires_test.go
@@ -1,0 +1,598 @@
+package sprint_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// fourEpicSyntheticFixture is the canonical issue #46 acceptance fixture:
+// four epics encoding every topology the resolver has to handle.
+//
+//	Epic 1: foundation (no requires)         — 1.1, 1.2, 1.3
+//	Epic 2: linear chain to 1                — 2.1, 2.2     requires_epics: [1]
+//	Epic 3: fan-out from 1                   — 3.1, 3.2     requires_epics: [1]
+//	Epic 4: diamond + multi-deps             — 4.1, 4.2     requires_epics: [2, 3]
+//	                                                       requires_stories: ["1.2"]
+//
+// After synthesis the planner-expected edges are:
+//
+//	2.1 → 1.3        (last of epic 1)
+//	2.2 → 1.3        (inherited from epic 2's requires_epics)
+//	3.1 → 1.3        (fan-out from epic 1)
+//	3.2 → 1.3
+//	4.1 → 2.2, 3.2, 1.2  (diamond + the cross-cutting story pin)
+//	4.2 → 2.2, 3.2, 1.2
+const fourEpicSyntheticFixture = `# Synthetic 4-Epic DAG (issue #46 acceptance)
+
+## Epic 1: Foundation
+
+### Story 1.1: Bootstrap
+
+---
+story_id: "1.1"
+---
+
+### Story 1.2: Cross-cutting Helper
+
+---
+story_id: "1.2"
+---
+
+### Story 1.3: Last of Epic 1
+
+---
+story_id: "1.3"
+---
+
+## Epic 2: Linear Chain to Epic 1
+
+---
+epic_id: 2
+requires_epics: [1]
+---
+
+### Story 2.1: First of Epic 2
+
+---
+story_id: "2.1"
+---
+
+### Story 2.2: Last of Epic 2
+
+---
+story_id: "2.2"
+---
+
+## Epic 3: Fan-out from Epic 1
+
+---
+epic_id: 3
+requires_epics: [1]
+---
+
+### Story 3.1: First of Epic 3
+
+---
+story_id: "3.1"
+---
+
+### Story 3.2: Last of Epic 3
+
+---
+story_id: "3.2"
+---
+
+## Epic 4: Diamond + Multi-deps
+
+---
+epic_id: 4
+requires_epics: [2, 3]
+requires_stories: ["1.2"]
+---
+
+### Story 4.1: First of Epic 4
+
+---
+story_id: "4.1"
+---
+
+### Story 4.2: Last of Epic 4
+
+---
+story_id: "4.2"
+---
+`
+
+func writeFixture(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestParseEpicsFileFull_CapturesEpicRequiresFrontmatter(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "epics.md", fourEpicSyntheticFixture)
+
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("ParseEpicsFileFull: %v", err)
+	}
+	if len(parsed.Epics) != 4 {
+		t.Fatalf("epics = %d, want 4", len(parsed.Epics))
+	}
+	if len(parsed.Stories) != 9 {
+		t.Fatalf("stories = %d, want 9 (3+2+2+2)", len(parsed.Stories))
+	}
+
+	// Epic 1: no requires
+	if parsed.Epics[0].EpicID != "1" {
+		t.Errorf("epics[0].EpicID = %q, want 1", parsed.Epics[0].EpicID)
+	}
+	if len(parsed.Epics[0].Frontmatter.RequiresEpics) != 0 {
+		t.Errorf("epic 1 should have no requires_epics; got %v", parsed.Epics[0].Frontmatter.RequiresEpics)
+	}
+
+	// Epic 4: requires [2,3] + requires_stories: ["1.2"]
+	got := parsed.Epics[3]
+	if got.EpicID != "4" {
+		t.Errorf("epics[3].EpicID = %q, want 4", got.EpicID)
+	}
+	if got.Frontmatter.EpicID != 4 {
+		t.Errorf("epics[3].Frontmatter.EpicID = %d, want 4", got.Frontmatter.EpicID)
+	}
+	if len(got.Frontmatter.RequiresEpics) != 2 || got.Frontmatter.RequiresEpics[0] != 2 || got.Frontmatter.RequiresEpics[1] != 3 {
+		t.Errorf("epic 4 requires_epics = %v, want [2,3]", got.Frontmatter.RequiresEpics)
+	}
+	if len(got.Frontmatter.RequiresStories) != 1 || got.Frontmatter.RequiresStories[0] != "1.2" {
+		t.Errorf("epic 4 requires_stories = %v, want [1.2]", got.Frontmatter.RequiresStories)
+	}
+	if !got.HasFrontmatter {
+		t.Errorf("epic 4: HasFrontmatter = false, want true")
+	}
+
+	// Every story carries its parent epic id (so the resolver can group them).
+	wantEpics := map[string]string{
+		"1.1": "1", "1.2": "1", "1.3": "1",
+		"2.1": "2", "2.2": "2",
+		"3.1": "3", "3.2": "3",
+		"4.1": "4", "4.2": "4",
+	}
+	for _, s := range parsed.Stories {
+		if got, want := s.EpicID, wantEpics[s.Frontmatter.StoryID]; got != want {
+			t.Errorf("story %s EpicID = %q, want %q", s.Frontmatter.StoryID, got, want)
+		}
+	}
+}
+
+func TestSynthesizeRequiresEpics_FourEpicDAG(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "epics.md", fourEpicSyntheticFixture)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("ParseEpicsFileFull: %v", err)
+	}
+	got := sprint.SynthesizeRequiresEpics(parsed.Epics, parsed.Stories)
+
+	want := map[string][]string{
+		// Epic 2 (linear chain to 1): every story gets last-of-1 = 1.3
+		"2.1": {"1.3"},
+		"2.2": {"1.3"},
+		// Epic 3 (fan-out from 1): same
+		"3.1": {"1.3"},
+		"3.2": {"1.3"},
+		// Epic 4 (diamond + 1.2 pin): last-of-2=2.2 + last-of-3=3.2 + 1.2
+		"4.1": {"1.2", "2.2", "3.2"},
+		"4.2": {"1.2", "2.2", "3.2"},
+	}
+	if len(got.SynthesizedDeps) != len(want) {
+		t.Errorf("synthesised story count = %d, want %d (got %v)",
+			len(got.SynthesizedDeps), len(want), got.SynthesizedDeps)
+	}
+	for sid, wantDeps := range want {
+		gotDeps := got.SynthesizedDeps[sid]
+		if !equalStringSlices(gotDeps, wantDeps) {
+			t.Errorf("synth for %s = %v, want %v", sid, gotDeps, wantDeps)
+		}
+	}
+	if len(got.Warnings) != 0 {
+		t.Errorf("expected no warnings on clean fixture, got %v", got.Warnings)
+	}
+}
+
+func TestSynthesizeRequiresEpics_BypassEpicRequires(t *testing.T) {
+	t.Parallel()
+	// 3.1 explicitly opts out of inheriting requires_epics: [1].
+	path := writeFixture(t, "epics.md", `
+## Epic 1
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+## Epic 3
+
+---
+epic_id: 3
+requires_epics: [1]
+---
+
+### Story 3.1: opts out
+
+---
+story_id: "3.1"
+bypass_epic_requires: [1]
+---
+
+### Story 3.2: still inherits
+
+---
+story_id: "3.2"
+---
+`)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	res := sprint.SynthesizeRequiresEpics(parsed.Epics, parsed.Stories)
+
+	if _, present := res.SynthesizedDeps["3.1"]; present {
+		t.Errorf("3.1 bypassed epic 1 but still got synthesized deps: %v", res.SynthesizedDeps["3.1"])
+	}
+	if got := res.SynthesizedDeps["3.2"]; !equalStringSlices(got, []string{"1.1"}) {
+		t.Errorf("3.2 inherited deps = %v, want [1.1]", got)
+	}
+}
+
+func TestSynthesizeRequiresEpics_SelfReferenceIsDropped(t *testing.T) {
+	t.Parallel()
+	// Epic 1 listing itself in requires_epics → no synthesized edges for any
+	// 1.* story (would create a self-cycle otherwise).
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+---
+epic_id: 1
+requires_epics: [1]
+---
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+### Story 1.2
+---
+story_id: "1.2"
+---
+`)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	res := sprint.SynthesizeRequiresEpics(parsed.Epics, parsed.Stories)
+	if len(res.SynthesizedDeps) != 0 {
+		t.Errorf("self-reference produced synthesized deps: %v", res.SynthesizedDeps)
+	}
+}
+
+func TestSynthesizeRequiresEpics_UnknownEpicWarns(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "epics.md", `## Epic 4
+
+---
+epic_id: 4
+requires_epics: [99]
+---
+
+### Story 4.1
+---
+story_id: "4.1"
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	res := sprint.SynthesizeRequiresEpics(parsed.Epics, parsed.Stories)
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected warning for unknown referenced epic 99, got none")
+	}
+	if len(res.SynthesizedDeps) != 0 {
+		t.Errorf("synthesised deps for unknown epic = %v, want none", res.SynthesizedDeps)
+	}
+}
+
+func TestDetectRequiresEpicsCycle_CatchesAB_BA(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+---
+epic_id: 1
+requires_epics: [2]
+---
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+## Epic 2
+
+---
+epic_id: 2
+requires_epics: [1]
+---
+
+### Story 2.1
+---
+story_id: "2.1"
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	cycle := sprint.DetectRequiresEpicsCycle(parsed.Epics)
+	if len(cycle) == 0 {
+		t.Fatalf("expected cycle detection, got nil")
+	}
+	// Cycle must visit both 1 and 2.
+	joined := strings.Join(cycle, " ")
+	if !strings.Contains(joined, "1") || !strings.Contains(joined, "2") {
+		t.Errorf("cycle = %v should reference epics 1 and 2", cycle)
+	}
+}
+
+func TestDetectRequiresEpicsCycle_AcyclicReturnsNil(t *testing.T) {
+	t.Parallel()
+	path := writeFixture(t, "epics.md", fourEpicSyntheticFixture)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	if cycle := sprint.DetectRequiresEpicsCycle(parsed.Epics); cycle != nil {
+		t.Errorf("acyclic fixture produced cycle: %v", cycle)
+	}
+}
+
+func TestDetectLinearChainPlaceholderSmell_FlagsPlaceholderPattern(t *testing.T) {
+	t.Parallel()
+	// Story 2.1 depends on 1.last (= 1.2) but Epic 2 has NO requires_epics —
+	// the canonical placeholder smell.
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+### Story 1.2
+---
+story_id: "1.2"
+---
+
+## Epic 2
+
+### Story 2.1
+---
+story_id: "2.1"
+depends_on: ["1.2"]
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	warnings := sprint.DetectLinearChainPlaceholderSmell(parsed.Epics, parsed.Stories)
+	if len(warnings) == 0 {
+		t.Fatalf("expected linear-chain smell warning, got none")
+	}
+	if !strings.Contains(warnings[0], "2.1") || !strings.Contains(warnings[0], "1.2") {
+		t.Errorf("warning %q should mention the story+target", warnings[0])
+	}
+}
+
+func TestDetectLinearChainPlaceholderSmell_SuppressedWhenRequiresEpicsDeclared(t *testing.T) {
+	t.Parallel()
+	// Same shape but Epic 2 declares requires_epics — author was explicit.
+	// The smell-detector should stay quiet.
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+## Epic 2
+
+---
+epic_id: 2
+requires_epics: [1]
+---
+
+### Story 2.1
+---
+story_id: "2.1"
+depends_on: ["1.1"]
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	warnings := sprint.DetectLinearChainPlaceholderSmell(parsed.Epics, parsed.Stories)
+	if len(warnings) != 0 {
+		t.Errorf("expected no smell when requires_epics declared; got %v", warnings)
+	}
+}
+
+// TestPlanWithEpics_FourEpicSyntheticDAG is the headline acceptance test
+// (criterion #6 / #7 in issue #46): a 4-epic synthetic fixture exercises
+// linear chain, fan-out, diamond, and multi-deps in one run, and the
+// planner must:
+//
+//  1. Persist every synthesized cross-epic edge to story_dependencies
+//  2. Produce a topo-sorted batch plan respecting both story-level AND
+//     synthesised deps
+//  3. Surface a non-zero SynthesizedDependenciesAdded count so an
+//     operator can see how much came from epic-level frontmatter
+func TestPlanWithEpics_FourEpicSyntheticDAG(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	planner := &sprint.Planner{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+		Affects:      sqlite.NewStoryAffectsStore(db),
+		Batches:      sqlite.NewBatchesStore(db),
+	}
+
+	path := writeFixture(t, "epics.md", fourEpicSyntheticFixture)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("ParseEpicsFileFull: %v", err)
+	}
+	ctx := context.Background()
+	res, err := planner.PlanWithEpics(ctx, parsed.Epics, parsed.Stories, 10)
+	if err != nil {
+		t.Fatalf("PlanWithEpics: %v", err)
+	}
+
+	if res.SynthesizedDependenciesAdded == 0 {
+		t.Errorf("SynthesizedDependenciesAdded = 0; want > 0 (resolver must have fired)")
+	}
+	if len(res.Warnings) != 0 {
+		t.Errorf("clean fixture produced warnings: %v", res.Warnings)
+	}
+
+	// Persisted edges must match what SynthesizeRequiresEpics returned.
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	wantPersisted := map[string][]string{
+		"2.1": {"1.3"},
+		"2.2": {"1.3"},
+		"3.1": {"1.3"},
+		"3.2": {"1.3"},
+		"4.1": {"1.2", "2.2", "3.2"},
+		"4.2": {"1.2", "2.2", "3.2"},
+	}
+	for sid, want := range wantPersisted {
+		got, err := depsStore.Of(ctx, sid)
+		if err != nil {
+			t.Fatalf("deps.Of %s: %v", sid, err)
+		}
+		if !equalStringSlices(got, want) {
+			t.Errorf("persisted deps for %s = %v, want %v", sid, got, want)
+		}
+	}
+
+	// Batch plan must produce four topological layers (Epic 1, then 2+3
+	// parallel — but no batch can contain a story from Epic 4 alongside
+	// its prerequisites). Lower bound is 3 layers; max 4 because the
+	// planner may split 1.* across multiple batches if max_parallel is
+	// hit — we set 10, so it shouldn't.
+	if res.BatchesCreated < 3 {
+		t.Errorf("BatchesCreated = %d; want >= 3 (Epic 1 layer, then dependents)", res.BatchesCreated)
+	}
+}
+
+// TestPlanWithEpics_CycleErrors confirms acceptance criterion #4: the
+// planner refuses to run when requires_epics forms a cycle, and does NOT
+// touch SQLite (an aborted plan must not leave a half-applied state).
+func TestPlanWithEpics_CycleErrors(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	planner := &sprint.Planner{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+		Affects:      sqlite.NewStoryAffectsStore(db),
+		Batches:      sqlite.NewBatchesStore(db),
+	}
+
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+---
+epic_id: 1
+requires_epics: [2]
+---
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+## Epic 2
+
+---
+epic_id: 2
+requires_epics: [1]
+---
+
+### Story 2.1
+---
+story_id: "2.1"
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	if _, err := planner.PlanWithEpics(context.Background(), parsed.Epics, parsed.Stories, 4); err == nil {
+		t.Fatalf("PlanWithEpics on cycle = nil; want error")
+	} else if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error %q should mention cycle", err.Error())
+	}
+
+	// Defensive check: no stories were inserted before the cycle detector
+	// fired (the cycle check is the first mutation gate).
+	rows, err := sqlite.NewStoriesStore(db).List(context.Background(), state.StoryFilter{})
+	if err != nil {
+		t.Fatalf("list stories: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("planner inserted %d rows despite cycle; want 0 (atomicity)", len(rows))
+	}
+}
+
+// TestPlanWithEpics_BackCompatNoFrontmatter confirms acceptance criterion
+// "backwards compatibility": an epics.md WITHOUT any requires_epics:
+// behaves exactly as the pre-#46 planner did. No synthesized edges, no
+// warnings, no behavior shift on the resulting batch plan.
+func TestPlanWithEpics_BackCompatNoFrontmatter(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	planner := &sprint.Planner{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+		Affects:      sqlite.NewStoryAffectsStore(db),
+		Batches:      sqlite.NewBatchesStore(db),
+	}
+	path := writeFixture(t, "epics.md", `## Epic 1
+
+### Story 1.1: Foo
+---
+story_id: "1.1"
+---
+
+### Story 1.2
+---
+story_id: "1.2"
+depends_on: ["1.1"]
+---
+`)
+	parsed, _ := sprint.ParseEpicsFileFull(path)
+	res, err := planner.PlanWithEpics(context.Background(), parsed.Epics, parsed.Stories, 10)
+	if err != nil {
+		t.Fatalf("PlanWithEpics: %v", err)
+	}
+	if res.SynthesizedDependenciesAdded != 0 {
+		t.Errorf("no requires_epics declared but SynthesizedDependenciesAdded = %d", res.SynthesizedDependenciesAdded)
+	}
+	if res.DependenciesAdded != 1 {
+		t.Errorf("DependenciesAdded = %d, want 1 (the explicit 1.2 → 1.1 edge)", res.DependenciesAdded)
+	}
+}
+
+// equalStringSlices: order-sensitive equality, since SynthesizeRequiresEpics
+// sorts its output deterministically (natural ordinal). Catches stable-sort
+// regressions too.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -83,10 +83,12 @@ Safety rails (issue #14):
 				}
 				epicsPath = filepath.Join(docs, "epics.md")
 			}
-			parsed, err := appsprint.ParseEpicsFile(epicsPath)
+			parsedFull, err := appsprint.ParseEpicsFileFull(epicsPath)
 			if err != nil {
 				return err
 			}
+			parsed := parsedFull.Stories
+			epics := parsedFull.Epics
 
 			// Apply --scope filter FIRST so coverage analysis only flags
 			// in-scope stories. A scope restricted to a fully-annotated
@@ -97,6 +99,18 @@ Safety rails (issue #14):
 				if len(parsed) == 0 {
 					return fmt.Errorf("sprint plan: --scope %q matched zero stories in %s", scope, epicsPath)
 				}
+				// Same idea for the epic-level headers: when planning a single
+				// epic, the cross-epic resolver should only see THAT epic's
+				// requires_epics frontmatter (otherwise out-of-scope synthesis
+				// would fan out into rows we're not touching). Restrict to the
+				// requested scope.
+				filteredEpics := make([]appsprint.ParsedEpic, 0, len(epics))
+				for _, e := range epics {
+					if e.EpicID == scope {
+						filteredEpics = append(filteredEpics, e)
+					}
+				}
+				epics = filteredEpics
 			}
 
 			// Partial-coverage safety check (issue #14, fix #1).
@@ -135,13 +149,20 @@ Safety rails (issue #14):
 				Affects:      sqlite.NewStoryAffectsStore(db),
 				Batches:      sqlite.NewBatchesStore(db),
 			}
-			res, err := planner.Plan(ctx, parsed, maxP)
+			res, err := planner.PlanWithEpics(ctx, epics, parsed, maxP)
 			if err != nil {
 				return err
 			}
 			if scope != "" {
 				res.Scope = scope
 				res.StoriesSkippedByScope = totalBeforeScope - len(parsed)
+			}
+			// Surface planner-level warnings (issue #46: placeholder
+			// linear-chain smell, missing referenced epics) to stderr
+			// regardless of --json — the operator wants to see them
+			// before deciding to dispatch.
+			for _, w := range res.Warnings {
+				fmt.Fprintln(os.Stderr, "warn:", w)
 			}
 			if jsonOutput {
 				args := map[string]any{}


### PR DESCRIPTION
## Summary

Implements issue #46 — `requires_epics:` + `requires_stories:` frontmatter
on each `## Epic N` header, plus a planner-side resolver that synthesises
cross-epic story edges at ingest time. Kills the linear-chain placeholder
pattern that authors had to maintain by hand whenever Epic N really
depended on Epic M (and that silently broke whenever Epic M's story
count shifted).

- **Parser** — `ParseEpicsFileFull` returns both epic headers (with
  optional `requires_epics:` / `requires_stories:` frontmatter) and
  stories. Back-compat wrapper `ParseEpicsFile` kept.
- **Resolver** (`application/sprint/requires.go`) — pure functions:
  - `SynthesizeRequiresEpics` expands epic-level requires into story-
    level edges (last-story-of-epic-R per natural ordinal, plus literal
    `requires_stories:` pins), deduped against the story's own
    `depends_on:`. Self-reference dropped. Unknown referenced epics
    produce non-fatal warnings.
  - `DetectRequiresEpicsCycle` — up-front DFS catches A→B + B→A
    (acceptance criterion #4); planner refuses to mutate SQLite when
    one is found.
  - `DetectLinearChainPlaceholderSmell` — warns when "first story of
    Epic N depends_on last story of Epic N-1" with no `requires_epics:`
    declared (acceptance criterion #5).
- **Story-level override** — `bypass_epic_requires: [N]` opts a single
  story out of one inherited epic requirement (documented escape valve,
  rare).
- **Planner** — new `PlanWithEpics` entry point; `Plan` is a thin
  back-compat wrapper. `IngestResult` now reports
  `SynthesizedDependenciesAdded` and `Warnings`.
- **CLI** — `bmad sprint plan` calls `PlanWithEpics`, prints warnings to
  stderr regardless of `--json`. `--scope <epic>` correctly restricts
  BOTH the story filter and the epic frontmatter the resolver sees.

## Schema

```markdown
## Epic 13: Slice 10 — commerce BC + S-2 + S-4 sagas

---
epic_id: 13
requires_epics: [4, 6, 12]
requires_stories: ["3.4"]
---

### Story 13.1: ...
```

## Tests

Headline test: `application/sprint/requires_test.go` ships a 4-epic
synthetic fixture covering linear chain, fan-out, diamond, and
multi-deps in one DAG (acceptance criteria #6 + #7). Additional tests
cover cycle detection, self-reference drop, unknown-epic warning,
bypass override, placeholder-smell detection + suppression, and a
back-compat assertion that epics without `requires_epics:` behave
byte-identical to the pre-#46 planner.

## Backwards compatibility

- Existing story-level `depends_on:` keeps working byte-identical.
- Epics without `requires_epics:` frontmatter behave exactly as
  today — story-level only.
- The story-header regex was loosened to accept titleless `### Story
  X.Y` headers (real-world authors commit titleless stubs while
  shaping the dependency graph); the existing test fixtures with
  explicit titles continue to parse unchanged.

## Out of scope (filed as separate issues per #46)

- `bmad sprint graph` visualisation — #47
- `bmad sprint validate-deps` orphan + missing-dep detection — #48
- `bmad-bmm-create-epics-and-stories` workflow update — nutrition
  repo #373

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -short` — all packages green
- [x] `go test ./application/sprint/inferdeps/` — adjacent parser tests still pass
- [x] 4-epic synthetic-DAG acceptance test passes