### PR TITLE
feat(sprint): validate-deps — cycle + orphan + missing-dep detection (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ bmad dispatch record ...           # §12.7 per-call token cost log
 bmad render <template>             # prompt template renderer
 
 bmad story    <status|hydrate|next|checkpoint|set-status|complete>
-bmad sprint   <plan|run|pause|resume|status>     # epics.md → batches → orchestration
+bmad sprint   <plan|run|pause|resume|status|validate-deps|infer-deps|cache-bundle>
+                                                  # epics.md → batches → orchestration
 bmad env      <up|down|status|cleanup-orphans>   # port pool + activity sweeper
 bmad worktree <create|destroy|list|prune>        # state tracking; git is caller's job
 bmad depguard <flip|status|history>              # per-rule warn↔error ratchet

--- a/application/sprint/validate.go
+++ b/application/sprint/validate.go
@@ -1,0 +1,686 @@
+package sprint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ---------- Public API ----------
+
+// FindingKind enumerates the validator's diagnostic categories. Stable; new
+// kinds must be additive — orchestrators key off these strings.
+type FindingKind string
+
+const (
+	FindingCycle             FindingKind = "cycle"
+	FindingOrphan            FindingKind = "orphan"
+	FindingMissingDep        FindingKind = "missing_dep"
+	FindingMissingEpicRef    FindingKind = "missing_epic_ref"
+	FindingPlaceholderSmell  FindingKind = "placeholder_smell"
+	FindingDiamond           FindingKind = "diamond"
+)
+
+// FindingSeverity drives the exit-code mapping.
+//
+//	error → caller exits VALIDATION_ERROR (30)
+//	warn  → exit 0 unless --strict is set
+//	info  → exit 0 always (advisory only)
+type FindingSeverity string
+
+const (
+	SeverityError FindingSeverity = "error"
+	SeverityWarn  FindingSeverity = "warn"
+	SeverityInfo  FindingSeverity = "info"
+)
+
+// Finding is one validator diagnostic. Field shape is the v1 wire contract
+// — additive evolution only.
+type Finding struct {
+	Kind        FindingKind     `json:"kind"`
+	Severity    FindingSeverity `json:"severity"`
+	InvolvedIDs []string        `json:"involved_ids"`
+	Message     string          `json:"message"`
+	// SuggestedFix is an optional, human-readable nudge — populated for
+	// placeholder_smell findings where we can point at the architecture
+	// doc the operator should consult.
+	SuggestedFix string `json:"suggested_fix,omitempty"`
+}
+
+// Counts is the per-severity tally rendered alongside Findings.
+type Counts struct {
+	Error int `json:"error"`
+	Warn  int `json:"warn"`
+	Info  int `json:"info"`
+}
+
+// ValidateReport is the result envelope's .result body.
+type ValidateReport struct {
+	Findings []Finding `json:"findings"`
+	Counts   Counts    `json:"counts"`
+	// Scope, when non-empty, echoes the --scope filter applied before the
+	// graph was walked.
+	Scope string `json:"scope,omitempty"`
+	// Strict echoes whether warn-level findings were escalated to errors
+	// for the exit-code decision.
+	Strict bool `json:"strict"`
+	// TotalStories is the count of stories considered by the validator
+	// (after scope filtering). Surfaced so consumers can sanity-check.
+	TotalStories int `json:"total_stories"`
+}
+
+// ValidateOptions parameterises a Validate call. Kept as a struct (not
+// positional args) so additive fields don't break callers.
+type ValidateOptions struct {
+	// Scope, when non-empty, restricts the validator to stories whose ID
+	// belongs to this epic id (see StoryMatchesEpic). Cross-epic edges
+	// pointing OUT of scope are still treated as missing-dep candidates
+	// when the target is absent from the input slice — same shape as
+	// `bmad sprint plan` partial-coverage rules.
+	Scope string
+
+	// Strict, when true, escalates orphan findings (default WARN) to
+	// errors so the caller exits non-zero. Other severities are unchanged.
+	Strict bool
+
+	// EpicRequires maps "epic id" → list of declared upstream epic ids
+	// it depends on (the future #46 `requires_epics:` field at the epic
+	// header). Used by the placeholder-smell detector to SUPPRESS the
+	// finding when "first story of Epic N depends_on last story of Epic
+	// N-1" matches an explicit `requires_epics: [N-1]` declaration.
+	//
+	// Nil map = no declarations parsed; every "linear-chain" pattern
+	// will be flagged. Once #46 lands, the cobra wrapper populates this
+	// from epic-level frontmatter.
+	EpicRequires map[string][]string
+}
+
+// Validate runs every detector over the parsed stories and returns a
+// deterministic Report (findings sorted by kind then by first involved id).
+//
+// The function is pure: no IO, no DB. Inputs in → findings out. Tests
+// inject ParsedStory fixtures directly; the cobra wrapper parses
+// epics.md first.
+func Validate(parsed []ParsedStory, opts ValidateOptions) ValidateReport {
+	scoped := parsed
+	if opts.Scope != "" {
+		scoped = FilterByScope(parsed, opts.Scope)
+	}
+
+	// Build a graph view of the scoped set. byID is the authoritative
+	// "this story exists in the input" check.
+	byID := make(map[string]ParsedStory, len(scoped))
+	order := make([]string, 0, len(scoped))
+	for _, ps := range scoped {
+		id := ps.Frontmatter.StoryID
+		if _, dup := byID[id]; !dup {
+			order = append(order, id)
+		}
+		byID[id] = ps
+	}
+
+	var findings []Finding
+	findings = append(findings, detectMissingDeps(byID, order)...)
+	findings = append(findings, detectCycles(byID, order)...)
+	findings = append(findings, detectOrphans(byID, order)...)
+	findings = append(findings, detectPlaceholderSmell(byID, order, opts.EpicRequires)...)
+	findings = append(findings, detectDiamonds(byID, order)...)
+
+	// Deterministic ordering: kind alpha, then involved_ids[0] alpha.
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Kind != findings[j].Kind {
+			return findings[i].Kind < findings[j].Kind
+		}
+		a, b := first(findings[i].InvolvedIDs), first(findings[j].InvolvedIDs)
+		return a < b
+	})
+
+	rep := ValidateReport{
+		Findings:     findings,
+		Strict:       opts.Strict,
+		Scope:        opts.Scope,
+		TotalStories: len(scoped),
+	}
+	for _, f := range findings {
+		switch f.Severity {
+		case SeverityError:
+			rep.Counts.Error++
+		case SeverityWarn:
+			rep.Counts.Warn++
+		case SeverityInfo:
+			rep.Counts.Info++
+		}
+	}
+	return rep
+}
+
+// HasBlockingFindings returns true if the report contains any severity that
+// must map to a non-zero exit code, given the strict flag.
+//
+//	Strict=false → only errors block.
+//	Strict=true  → errors + warns both block.
+//
+// Info-level never blocks.
+func (r ValidateReport) HasBlockingFindings() bool {
+	if r.Counts.Error > 0 {
+		return true
+	}
+	if r.Strict && r.Counts.Warn > 0 {
+		return true
+	}
+	return false
+}
+
+// ---------- Detectors ----------
+
+// detectMissingDeps flags `depends_on` entries pointing to a story id that
+// is not present in the parsed set. Severity = error (graph is broken).
+//
+// Out-of-scope handling: when scope is restricted, missing-dep can be a
+// false positive if the target lives in a different epic. We don't have
+// enough information here to distinguish "external done dep" from "typo"
+// — by convention the validator runs against the FULL epics.md file
+// (scope filters the start set, but the byID lookup is built from the
+// scoped slice). Operators who want to validate a single epic in
+// isolation can pre-filter; otherwise they should validate the whole
+// file. We make this explicit in the message text.
+func detectMissingDeps(byID map[string]ParsedStory, order []string) []Finding {
+	var out []Finding
+	for _, id := range order {
+		ps := byID[id]
+		for _, dep := range ps.Frontmatter.DependsOn {
+			if dep == "" {
+				continue
+			}
+			if _, ok := byID[dep]; ok {
+				continue
+			}
+			out = append(out, Finding{
+				Kind:        FindingMissingDep,
+				Severity:    SeverityError,
+				InvolvedIDs: []string{id, dep},
+				Message: fmt.Sprintf(
+					"Story %s depends_on non-existent story %q (not present in input set)",
+					id, dep),
+			})
+		}
+	}
+	return out
+}
+
+// detectCycles runs an iterative three-color DFS over the dependency
+// graph. We use the iterative form to keep the call stack bounded on
+// deep dep chains, and we report ONE finding per cycle (the canonical
+// closed walk from the back-edge target back to itself).
+//
+// The graph direction we walk: edge A → B means "A depends_on B"
+// (A waits for B). A cycle is therefore a closed walk where each step
+// is a depends_on transition.
+func detectCycles(byID map[string]ParsedStory, order []string) []Finding {
+	const (
+		white = 0 // unvisited
+		gray  = 1 // on the current DFS stack
+		black = 2 // fully explored
+	)
+	color := make(map[string]int, len(order))
+	parent := make(map[string]string, len(order))
+
+	var cycles [][]string
+	seen := map[string]bool{} // dedupe by canonical cycle key
+
+	var visit func(start string)
+	visit = func(start string) {
+		// Iterative DFS with an explicit (node, iter-index) stack so we
+		// can detect back-edges + reconstruct the cycle.
+		type frame struct {
+			node string
+			next int // index into the next dep to visit
+		}
+		stack := []frame{{node: start, next: 0}}
+		color[start] = gray
+		for len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			ps := byID[top.node]
+			deps := ps.Frontmatter.DependsOn
+			if top.next >= len(deps) {
+				color[top.node] = black
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			dep := deps[top.next]
+			top.next++
+			if dep == "" {
+				continue
+			}
+			if _, ok := byID[dep]; !ok {
+				continue // missing-dep — reported by its own detector
+			}
+			switch color[dep] {
+			case white:
+				parent[dep] = top.node
+				color[dep] = gray
+				stack = append(stack, frame{node: dep, next: 0})
+			case gray:
+				// Back-edge: reconstruct cycle dep → ... → top.node → dep.
+				cycle := []string{dep}
+				cur := top.node
+				for cur != dep && cur != "" {
+					cycle = append(cycle, cur)
+					cur = parent[cur]
+				}
+				cycle = append(cycle, dep)
+				// reverse so the walk reads in dependency-order:
+				// "dep → ... → top.node → dep". The slice above was
+				// built from back-edge target walking BACK through
+				// parents, so we reverse to present forward.
+				reverseStrings(cycle)
+				key := cycleKey(cycle)
+				if !seen[key] {
+					seen[key] = true
+					cycles = append(cycles, cycle)
+				}
+			}
+		}
+	}
+
+	for _, id := range order {
+		if color[id] == white {
+			visit(id)
+		}
+	}
+
+	out := make([]Finding, 0, len(cycles))
+	for _, c := range cycles {
+		out = append(out, Finding{
+			Kind:        FindingCycle,
+			Severity:    SeverityError,
+			InvolvedIDs: c,
+			Message:     "Cycle: " + strings.Join(c, " -> "),
+		})
+	}
+	return out
+}
+
+// reverseStrings reverses s in place.
+func reverseStrings(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}
+
+// cycleKey canonicalises a cycle path for dedup so the same cycle
+// discovered from two different DFS entry points only reports once.
+// We rotate the slice so the smallest id is first, then join.
+func cycleKey(cycle []string) string {
+	if len(cycle) < 2 {
+		return strings.Join(cycle, "|")
+	}
+	// drop trailing duplicate of the start (we render closed walks with
+	// the start id appearing twice — strip one for canonicalisation).
+	body := cycle[:len(cycle)-1]
+	minIdx := 0
+	for i := 1; i < len(body); i++ {
+		if body[i] < body[minIdx] {
+			minIdx = i
+		}
+	}
+	rot := append([]string{}, body[minIdx:]...)
+	rot = append(rot, body[:minIdx]...)
+	return strings.Join(rot, "|")
+}
+
+// detectOrphans flags stories that have no dependents (no other story
+// in the set has them in `depends_on`) AND are not the last story of
+// their epic.
+//
+// "Last story of epic" is determined positionally: the story with the
+// highest numeric suffix within the epic id prefix. We use a numeric
+// compare when the suffix parses as an integer; otherwise lexicographic.
+// This matches the convention used elsewhere in the planner.
+//
+// Severity = warn (it's often a typo, but legitimate side-quest stories
+// can have no dependents — e.g. a one-off doc fix in the middle of an
+// epic). --strict escalates these to errors.
+func detectOrphans(byID map[string]ParsedStory, order []string) []Finding {
+	// dependents[id] = set of stories that depend on id
+	dependents := make(map[string]map[string]bool, len(order))
+	for _, id := range order {
+		ps := byID[id]
+		for _, dep := range ps.Frontmatter.DependsOn {
+			if dep == "" {
+				continue
+			}
+			if _, ok := byID[dep]; !ok {
+				continue
+			}
+			if dependents[dep] == nil {
+				dependents[dep] = map[string]bool{}
+			}
+			dependents[dep][id] = true
+		}
+	}
+
+	// Group story ids by epic.
+	byEpic := make(map[string][]string)
+	for _, id := range order {
+		epic := EpicIDFromStory(id)
+		byEpic[epic] = append(byEpic[epic], id)
+	}
+	lastOfEpic := make(map[string]string)
+	for epic, ids := range byEpic {
+		last := pickLastByStorySuffix(ids)
+		lastOfEpic[epic] = last
+	}
+
+	var out []Finding
+	for _, id := range order {
+		if len(dependents[id]) > 0 {
+			continue
+		}
+		epic := EpicIDFromStory(id)
+		if lastOfEpic[epic] == id {
+			continue
+		}
+		out = append(out, Finding{
+			Kind:        FindingOrphan,
+			Severity:    SeverityWarn,
+			InvolvedIDs: []string{id},
+			Message: fmt.Sprintf(
+				"Story %s has no successors and is not the last story of Epic %s — likely a missing depends_on linkage elsewhere",
+				id, epic),
+		})
+	}
+	return out
+}
+
+// pickLastByStorySuffix returns the story id with the largest suffix
+// after the first dot. Numeric compare when possible, else lexicographic.
+// Empty input returns "".
+func pickLastByStorySuffix(ids []string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	best := ids[0]
+	for _, id := range ids[1:] {
+		if compareStorySuffix(id, best) > 0 {
+			best = id
+		}
+	}
+	return best
+}
+
+// compareStorySuffix orders two story ids by their post-first-dot suffix.
+// Returns >0 if a > b, <0 if a < b, 0 if equal.
+//
+// Strategy: take everything after the first dot; if both suffixes parse
+// as ints, compare numerically; otherwise lex. This handles "1.10 > 1.9"
+// correctly (numeric) while still ordering "4.1.payment > 4.1.identity"
+// lexicographically.
+func compareStorySuffix(a, b string) int {
+	sa := suffixAfterFirstDot(a)
+	sb := suffixAfterFirstDot(b)
+	if ia, ok1 := parseStoryNumber(sa); ok1 {
+		if ib, ok2 := parseStoryNumber(sb); ok2 {
+			switch {
+			case ia > ib:
+				return 1
+			case ia < ib:
+				return -1
+			default:
+				return 0
+			}
+		}
+	}
+	switch {
+	case sa > sb:
+		return 1
+	case sa < sb:
+		return -1
+	default:
+		return 0
+	}
+}
+
+func suffixAfterFirstDot(id string) string {
+	if i := strings.IndexByte(id, '.'); i >= 0 {
+		return id[i+1:]
+	}
+	return id
+}
+
+// parseStoryNumber returns (n, true) only when s is a pure unsigned int.
+func parseStoryNumber(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, true
+}
+
+// detectPlaceholderSmell flags the "first story of Epic N depends_on last
+// story of Epic N-1, with no epic-level requires_epics: [N-1] declared".
+// This is a heuristic — it intentionally errs on the side of surfacing
+// noise the operator can then clear, because the cost of a missed real
+// cross-epic dep is much higher than the cost of an extra INFO line.
+//
+// Suppression: when EpicRequires[N] contains "N-1", we skip the finding
+// (the operator has explicitly declared the cross-epic relationship at
+// the epic level, so the linear-chain frontmatter is intentional, not
+// a placeholder).
+//
+// Defensive code path for #46: if EpicRequires is nil OR lacks an entry
+// for Epic N, we emit the finding. Once #46 lands and the cobra wrapper
+// populates the map from epic-level frontmatter, declarations will start
+// suppressing matches without any change to the detector.
+func detectPlaceholderSmell(byID map[string]ParsedStory, order []string, epicRequires map[string][]string) []Finding {
+	// Group ids by epic.
+	byEpic := make(map[string][]string)
+	for _, id := range order {
+		byEpic[EpicIDFromStory(id)] = append(byEpic[EpicIDFromStory(id)], id)
+	}
+
+	// firstOfEpic[epic] = lowest-suffix story in epic.
+	firstOfEpic := make(map[string]string, len(byEpic))
+	lastOfEpic := make(map[string]string, len(byEpic))
+	for epic, ids := range byEpic {
+		first := ids[0]
+		last := ids[0]
+		for _, id := range ids[1:] {
+			if compareStorySuffix(id, first) < 0 {
+				first = id
+			}
+			if compareStorySuffix(id, last) > 0 {
+				last = id
+			}
+		}
+		firstOfEpic[epic] = first
+		lastOfEpic[epic] = last
+	}
+
+	var out []Finding
+	for _, id := range order {
+		epic := EpicIDFromStory(id)
+		if firstOfEpic[epic] != id {
+			continue // only first-of-epic candidates can smell
+		}
+		ps := byID[id]
+		// Need exactly one depends_on entry, and it must be the last
+		// story of a numerically-adjacent earlier epic.
+		if len(ps.Frontmatter.DependsOn) != 1 {
+			continue
+		}
+		dep := ps.Frontmatter.DependsOn[0]
+		depEpic := EpicIDFromStory(dep)
+		if depEpic == epic {
+			continue // same-epic intra-link is normal, not a smell
+		}
+		if !isPreviousEpicNumeric(epic, depEpic) {
+			continue
+		}
+		if lastOfEpic[depEpic] != dep {
+			continue
+		}
+		// Suppression — explicit requires_epics declaration.
+		if declared := epicRequires[epic]; containsString(declared, depEpic) {
+			continue
+		}
+		out = append(out, Finding{
+			Kind:        FindingPlaceholderSmell,
+			Severity:    SeverityInfo,
+			InvolvedIDs: []string{id, dep},
+			Message: fmt.Sprintf(
+				"Story %s is the first of Epic %s and only depends on %s (last of Epic %s) — likely a linear-chain placeholder rather than a real semantic dep",
+				id, epic, dep, depEpic),
+			SuggestedFix: fmt.Sprintf(
+				"Either declare an epic-level `requires_epics: [%q]` at the Epic %s header (see docs/architecture/eda-cutover/saga-to-slice-mapping*.md) OR replace this depends_on with the specific story(ies) Story %s actually consumes from.",
+				depEpic, epic, id),
+		})
+	}
+	return out
+}
+
+// isPreviousEpicNumeric returns true when both epic and prevCandidate
+// parse as ints and prevCandidate == epic - 1. Non-numeric epic ids
+// (e.g. slug-style "plans-patient") never trigger the smell — we lack
+// a notion of "previous" for them.
+func isPreviousEpicNumeric(epic, prevCandidate string) bool {
+	a, ok1 := parseStoryNumber(epic)
+	b, ok2 := parseStoryNumber(prevCandidate)
+	if !ok1 || !ok2 {
+		return false
+	}
+	return b == a-1
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// detectDiamonds flags ids that have ≥2 distinct dependency-paths
+// converging on the same ancestor. A diamond is sometimes legit
+// (a synchronisation point where one story really does consume two
+// upstreams that share a common predecessor) — severity is therefore
+// INFO. The motivation is observability: surfacing diamonds tells the
+// orchestrator's batch planner that the converging story will block
+// behind whichever path finishes last.
+//
+// Detection: for each story S, walk its transitive ancestor set via
+// BFS counting visit-paths (NOT just visited nodes). Any ancestor with
+// >1 visit-path through S's direct deps is a diamond apex.
+func detectDiamonds(byID map[string]ParsedStory, order []string) []Finding {
+	// Pre-compute transitive ancestors per direct-dep so we can attribute
+	// shared ancestors.
+	out := []Finding{}
+	for _, id := range order {
+		ps := byID[id]
+		directDeps := uniqueExisting(ps.Frontmatter.DependsOn, byID)
+		if len(directDeps) < 2 {
+			continue
+		}
+		// Per-direct-dep reachable set.
+		reachByDep := make(map[string]map[string]bool, len(directDeps))
+		for _, dep := range directDeps {
+			reachByDep[dep] = ancestorsOf(dep, byID)
+		}
+		// An ancestor that's reachable through ≥2 distinct directDeps is
+		// a diamond apex.
+		counts := map[string]int{}
+		for _, dep := range directDeps {
+			for anc := range reachByDep[dep] {
+				counts[anc]++
+			}
+		}
+		var apexes []string
+		for anc, n := range counts {
+			if n >= 2 {
+				apexes = append(apexes, anc)
+			}
+		}
+		if len(apexes) == 0 {
+			continue
+		}
+		sort.Strings(apexes)
+		// Emit one finding per (story, apex) pair so consumers can group
+		// findings cleanly.
+		for _, apex := range apexes {
+			out = append(out, Finding{
+				Kind:        FindingDiamond,
+				Severity:    SeverityInfo,
+				InvolvedIDs: []string{id, apex},
+				Message: fmt.Sprintf(
+					"Story %s has multiple dependency paths converging on %s (diamond) — review whether the convergence is intentional",
+					id, apex),
+			})
+		}
+	}
+	return out
+}
+
+// uniqueExisting filters a depends_on slice down to ids actually present
+// in the parsed set, deduping while preserving first-seen order. Used
+// by diamond detection so a duplicate edge (e.g. depends_on: ["a", "a"])
+// doesn't masquerade as two-path convergence.
+func uniqueExisting(deps []string, byID map[string]ParsedStory) []string {
+	seen := make(map[string]bool, len(deps))
+	out := make([]string, 0, len(deps))
+	for _, d := range deps {
+		if d == "" {
+			continue
+		}
+		if _, ok := byID[d]; !ok {
+			continue
+		}
+		if seen[d] {
+			continue
+		}
+		seen[d] = true
+		out = append(out, d)
+	}
+	return out
+}
+
+// ancestorsOf returns the transitive ancestor set of start (excluding
+// start itself). Used by diamond detection. Iterative BFS to stay
+// bounded on deep chains.
+func ancestorsOf(start string, byID map[string]ParsedStory) map[string]bool {
+	out := map[string]bool{}
+	queue := []string{start}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		ps := byID[cur]
+		for _, dep := range ps.Frontmatter.DependsOn {
+			if dep == "" {
+				continue
+			}
+			if _, ok := byID[dep]; !ok {
+				continue
+			}
+			if out[dep] {
+				continue
+			}
+			out[dep] = true
+			queue = append(queue, dep)
+		}
+	}
+	return out
+}
+
+// first returns the head of a slice or "" when empty. Used for ordering.
+func first(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}

--- a/application/sprint/validate_test.go
+++ b/application/sprint/validate_test.go
@@ -1,0 +1,309 @@
+package sprint_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+)
+
+// mkStory is a small helper that keeps the synthetic-fixture call sites
+// readable — every test below builds a []ParsedStory by hand.
+func mkStory(id string, deps ...string) sprint.ParsedStory {
+	return sprint.ParsedStory{
+		Frontmatter: sprint.StoryFrontmatter{
+			StoryID:   id,
+			DependsOn: deps,
+		},
+		HasFrontmatter: true,
+	}
+}
+
+// findKinds returns a count-by-kind map for terse fixture assertions.
+func findKinds(r sprint.ValidateReport) map[sprint.FindingKind]int {
+	out := map[sprint.FindingKind]int{}
+	for _, f := range r.Findings {
+		out[f.Kind]++
+	}
+	return out
+}
+
+// Fixture 1 — clean baseline. A linear DAG inside a single epic (no
+// cross-epic linear-chain placeholder smell) should produce zero findings.
+//
+// Topology:
+//
+//	1.1 → 1.2 → 1.3
+func TestValidate_CleanBaseline(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"),
+		mkStory("1.3", "1.2"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	if len(rep.Findings) != 0 {
+		t.Fatalf("expected zero findings on clean DAG, got: %+v", rep.Findings)
+	}
+	if rep.HasBlockingFindings() {
+		t.Errorf("clean DAG must not block")
+	}
+	if rep.TotalStories != 3 {
+		t.Errorf("TotalStories = %d, want 3", rep.TotalStories)
+	}
+}
+
+// Fixture 2 — cycle. 3.2 → 3.4 → 3.2 forms a closed walk; exit must be
+// blocking and the cycle path must include both ids.
+func TestValidate_CycleDetected(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("3.1"),
+		mkStory("3.2", "3.4"),
+		mkStory("3.3"),
+		mkStory("3.4", "3.2"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingCycle] != 1 {
+		t.Fatalf("expected exactly one cycle finding, got %+v\n%+v", kinds, rep.Findings)
+	}
+	if !rep.HasBlockingFindings() {
+		t.Errorf("cycle must block (exit-30)")
+	}
+	if rep.Counts.Error < 1 {
+		t.Errorf("cycle must count as ERROR, got counts=%+v", rep.Counts)
+	}
+	var cycleFinding sprint.Finding
+	for _, f := range rep.Findings {
+		if f.Kind == sprint.FindingCycle {
+			cycleFinding = f
+			break
+		}
+	}
+	// Cycle path must mention both involved ids.
+	joined := strings.Join(cycleFinding.InvolvedIDs, ",")
+	if !strings.Contains(joined, "3.2") || !strings.Contains(joined, "3.4") {
+		t.Errorf("cycle path missing 3.2 and/or 3.4: %v", cycleFinding.InvolvedIDs)
+	}
+	if !strings.Contains(cycleFinding.Message, "->") {
+		t.Errorf("cycle message should render the walk with '->', got %q", cycleFinding.Message)
+	}
+}
+
+// Fixture 3 — orphan. 1.2 has no dependents AND is not the last story of
+// its epic (1.3 exists). Default severity = WARN, no exit blocking;
+// --strict flips it.
+func TestValidate_OrphanDefaultWarn(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"), // orphan: nobody depends on it, not last
+		mkStory("1.3", "1.1"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingOrphan] != 1 {
+		t.Fatalf("expected one orphan finding, got %+v\n%+v", kinds, rep.Findings)
+	}
+	if rep.HasBlockingFindings() {
+		t.Errorf("orphan WARN must NOT block default exit (got Counts=%+v Strict=%v)",
+			rep.Counts, rep.Strict)
+	}
+
+	// With --strict, the same fixture must block.
+	repStrict := sprint.Validate(parsed, sprint.ValidateOptions{Strict: true})
+	if !repStrict.HasBlockingFindings() {
+		t.Errorf("orphan + --strict must block")
+	}
+}
+
+// Fixture 4 — missing dep. 5.1 depends on 4.9 which does not exist in
+// the input set. Severity = ERROR, blocking.
+func TestValidate_MissingDepNonExistent(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("5.1", "4.9"), // 4.9 does not exist
+		mkStory("5.2"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingMissingDep] != 1 {
+		t.Fatalf("expected one missing_dep, got %+v\n%+v", kinds, rep.Findings)
+	}
+	if !rep.HasBlockingFindings() {
+		t.Errorf("missing_dep must block (exit-30)")
+	}
+	// Verify the message mentions both the dependent and the missing target.
+	var mdFinding sprint.Finding
+	for _, f := range rep.Findings {
+		if f.Kind == sprint.FindingMissingDep {
+			mdFinding = f
+			break
+		}
+	}
+	if !strings.Contains(mdFinding.Message, "5.1") || !strings.Contains(mdFinding.Message, "4.9") {
+		t.Errorf("missing_dep message should name 5.1 and 4.9: %q", mdFinding.Message)
+	}
+}
+
+// Fixture 5 — placeholder smell. First story of Epic 2 depends only on
+// last story of Epic 1, with no epic-level requires_epics declared.
+// Severity = INFO, never blocks. Suggested fix points at the EDA cutover
+// doc.
+func TestValidate_PlaceholderSmell(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"), // last of Epic 1
+		mkStory("2.1", "1.2"), // first of Epic 2 → linear-chain placeholder
+		mkStory("2.2", "2.1"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingPlaceholderSmell] != 1 {
+		t.Fatalf("expected one placeholder_smell, got %+v\n%+v", kinds, rep.Findings)
+	}
+	if rep.HasBlockingFindings() {
+		t.Errorf("placeholder_smell INFO must not block")
+	}
+	// Verify the suggested-fix nudges at the architecture doc.
+	for _, f := range rep.Findings {
+		if f.Kind == sprint.FindingPlaceholderSmell {
+			if !strings.Contains(f.SuggestedFix, "requires_epics") {
+				t.Errorf("suggested_fix should mention requires_epics: %q", f.SuggestedFix)
+			}
+			if !strings.Contains(f.SuggestedFix, "saga-to-slice-mapping") {
+				t.Errorf("suggested_fix should reference the saga-to-slice mapping doc: %q", f.SuggestedFix)
+			}
+		}
+	}
+}
+
+// Same fixture as above but WITH an explicit requires_epics declaration —
+// the placeholder smell must be suppressed (defensive code path for #46).
+func TestValidate_PlaceholderSmellSuppressedByRequiresEpics(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"),
+		mkStory("2.1", "1.2"),
+		mkStory("2.2", "2.1"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{
+		EpicRequires: map[string][]string{"2": {"1"}},
+	})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingPlaceholderSmell] != 0 {
+		t.Fatalf("placeholder_smell should be suppressed by requires_epics, got %+v\n%+v",
+			kinds, rep.Findings)
+	}
+}
+
+// Fixture 6 — diamond. 1.4 has two paths converging on 1.1 (via 1.2 and
+// via 1.3). Severity = INFO.
+//
+//	    1.1
+//	   /   \
+//	 1.2   1.3
+//	   \   /
+//	    1.4
+func TestValidate_Diamond(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"),
+		mkStory("1.3", "1.1"),
+		mkStory("1.4", "1.2", "1.3"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	kinds := findKinds(rep)
+	if kinds[sprint.FindingDiamond] < 1 {
+		t.Fatalf("expected at least one diamond finding, got %+v\n%+v",
+			kinds, rep.Findings)
+	}
+	if rep.HasBlockingFindings() {
+		t.Errorf("diamond INFO must not block")
+	}
+	// The apex must be 1.1 and the converging story must be 1.4.
+	var diamond sprint.Finding
+	for _, f := range rep.Findings {
+		if f.Kind == sprint.FindingDiamond {
+			diamond = f
+			break
+		}
+	}
+	if !contains(diamond.InvolvedIDs, "1.4") || !contains(diamond.InvolvedIDs, "1.1") {
+		t.Errorf("diamond involved_ids should include 1.4 and 1.1: %v", diamond.InvolvedIDs)
+	}
+}
+
+// Counts must aggregate by severity across multiple finding kinds.
+func TestValidate_CountsAggregate(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("5.1", "4.9"), // missing_dep → ERROR
+		mkStory("5.2", "5.3"),
+		mkStory("5.3", "5.2"), // cycle → ERROR
+		mkStory("5.4", "5.1"), // orphan because 5.4 has no dependents; not last (5.5 below)
+		mkStory("5.5", "5.4"),
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	if rep.Counts.Error < 2 {
+		t.Errorf("expected >=2 errors (cycle + missing_dep), got %+v", rep.Counts)
+	}
+	if !rep.HasBlockingFindings() {
+		t.Errorf("multi-error fixture must block")
+	}
+}
+
+// Scope filtering: stories outside scope must not be considered, and the
+// report's TotalStories must reflect the post-scope set.
+func TestValidate_ScopeFilter(t *testing.T) {
+	t.Parallel()
+	parsed := []sprint.ParsedStory{
+		mkStory("1.1"),
+		mkStory("1.2", "1.1"),
+		mkStory("2.1", "2.2"), // missing_dep, but only if 2.x is in scope
+		mkStory("2.2", "2.1"), // cycle, ditto
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{Scope: "1"})
+	if rep.TotalStories != 2 {
+		t.Fatalf("TotalStories = %d, want 2 (scope=1)", rep.TotalStories)
+	}
+	if len(rep.Findings) != 0 {
+		t.Errorf("scope=1 should suppress Epic-2 findings, got %+v", rep.Findings)
+	}
+	if rep.Scope != "1" {
+		t.Errorf("Scope echo = %q, want %q", rep.Scope, "1")
+	}
+}
+
+// Validates JSON tag stability of the report payload — the wire shape is
+// part of the v1 envelope contract, so changing it must be an intentional
+// breaking change with a CHANGELOG note.
+func TestValidate_ReportTagsStable(t *testing.T) {
+	t.Parallel()
+	// This test is a structural canary: refactoring the struct fields
+	// will need explicit reconfirmation by editing the assertions.
+	parsed := []sprint.ParsedStory{
+		mkStory("a.1", "a.2"),
+		mkStory("a.2", "a.1"), // forces a cycle so .findings is non-empty
+	}
+	rep := sprint.Validate(parsed, sprint.ValidateOptions{})
+	if rep.Findings[0].Kind != sprint.FindingCycle {
+		t.Fatalf("expected cycle, got %v", rep.Findings[0].Kind)
+	}
+	if rep.Findings[0].Severity != sprint.SeverityError {
+		t.Errorf("severity contract drift: %q", rep.Findings[0].Severity)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -34,6 +34,7 @@ func newSprintCmd() *cobra.Command {
 		newSprintStatusCmd(),
 		newSprintCacheBundleCmd(),
 		newSprintInferDepsCmd(),
+		newSprintValidateDepsCmd(),
 	)
 	addV6PersistentFlags(cmd)
 	return cmd

--- a/cmd/sprint_validate_deps.go
+++ b/cmd/sprint_validate_deps.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	appsprint "github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/cmd/exitcode"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// newSprintValidateDepsCmd wires `bmad sprint validate-deps` — closes #48.
+//
+// Detection model (delegated to application/sprint.Validate):
+//
+//   - cycle              (ERROR — graph is broken)
+//   - missing_dep        (ERROR — depends_on points at a non-existent id)
+//   - orphan             (WARN  — no dependents AND not last of epic;
+//                         escalated to ERROR via --strict)
+//   - placeholder_smell  (INFO  — first-of-epic depends only on last-of-prev)
+//   - diamond            (INFO  — multiple paths converge on one ancestor)
+//
+// Exit code contract:
+//
+//   exitcode.Success (0)           — no blocking findings
+//   exitcode.ValidationError (30)  — any error (or warn when --strict)
+//
+// We deliberately keep the orphan default at warn (exit 0): orchestrators
+// running validate-deps as a periodic check shouldn't see CI go red over
+// what's usually a side-quest doc story. Operators who want strict gates
+// (PR pre-merge hook, etc.) opt in with --strict.
+func newSprintValidateDepsCmd() *cobra.Command {
+	var (
+		epicsPath string
+		scope     string
+		strict    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "validate-deps",
+		Short: "Detect cycles, orphans, missing deps, and placeholder-smell in epics.md (closes #48)",
+		Long: `Walks the dependency graph parsed from epics.md and reports:
+
+  cycle              ERROR  A->B->...->A walks; ` + "`bmad story next`" + ` would stall.
+  missing_dep        ERROR  ` + "`depends_on`" + ` points at a non-existent story id.
+  orphan             WARN   Story has no successors AND is not last of its epic
+                            (often a missed downstream linkage). --strict
+                            escalates to ERROR.
+  placeholder_smell  INFO   First story of Epic N depends only on last of Epic
+                            N-1, with no epic-level ` + "`requires_epics:`" + ` declared
+                            — likely a conservative linear placeholder rather
+                            than a real semantic dependency.
+  diamond            INFO   Two+ dep-paths converge on a shared ancestor.
+                            Sometimes legit (synchronisation point); flagged
+                            so the operator can decide.
+
+Exit codes (` + "`bmad doctor`" + ` shows the full contract):
+
+  0                          no blocking findings
+  30 (VALIDATION_ERROR)      one or more ERROR findings (or WARN + --strict)`,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			// Resolve epicsPath from config.docs_folder when omitted, mirroring
+			// the convention of `bmad sprint plan` and `bmad sprint infer-deps`.
+			if epicsPath == "" {
+				db, err := openV6DB(ctx)
+				if err != nil {
+					return err
+				}
+				defer db.Close()
+				cfg := sqlite.NewConfigStore(db)
+				docs, err := cfg.Get(ctx, "docs_folder")
+				if err != nil {
+					return fmt.Errorf("sprint validate-deps: --epics required (docs_folder not set: %w)", err)
+				}
+				epicsPath = filepath.Join(docs, "epics.md")
+			}
+
+			parsed, err := appsprint.ParseEpicsFile(epicsPath)
+			if err != nil {
+				return err
+			}
+
+			report := appsprint.Validate(parsed, appsprint.ValidateOptions{
+				Scope:  scope,
+				Strict: strict,
+				// EpicRequires intentionally nil for now — issue #46 will
+				// add epic-level frontmatter parsing. When it does, this
+				// is the single place to wire it in:
+				//
+				//   EpicRequires: appsprint.ParseEpicRequires(epicsPath),
+				//
+				// Until then, every "first-of-epic depends_on last-of-prev"
+				// match emits a placeholder_smell INFO finding (the
+				// suggestion text tells the operator how to fix it).
+				EpicRequires: nil,
+			})
+
+			if jsonOutput {
+				cmdArgs := map[string]any{
+					"epics":  epicsPath,
+					"strict": strict,
+				}
+				if scope != "" {
+					cmdArgs["scope"] = scope
+				}
+				if err := emitJSONStdout(commandPathSansRoot(c), cmdArgs, report, nil); err != nil {
+					return err
+				}
+			} else {
+				emitValidateText(os.Stdout, report)
+			}
+
+			if report.HasBlockingFindings() {
+				// Exit with the stable validation code so orchestrators can
+				// branch on it. We bypass exitOnError's generic exit-1 mapping
+				// by os.Exit'ing directly; cobra's RunE return is intentionally
+				// suppressed to nil so the wrapper doesn't double-print.
+				os.Exit(exitcode.ValidationError.Int())
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&epicsPath, "epics", "", "epics.md path (default: <docs_folder>/epics.md)")
+	cmd.Flags().StringVar(&scope, "scope", "", "restrict validation to one epic id (e.g. 4 → only 4.* stories)")
+	cmd.Flags().BoolVar(&strict, "strict", false, "escalate WARN findings (orphans) to errors for the exit-code decision")
+	return cmd
+}
+
+// emitValidateText renders a short human-readable summary. JSON callers
+// take the envelope path instead.
+func emitValidateText(w *os.File, r appsprint.ValidateReport) {
+	if len(r.Findings) == 0 {
+		fmt.Fprintf(w, "OK — %d stories validated, no findings\n", r.TotalStories)
+		return
+	}
+	fmt.Fprintf(w, "%d findings across %d stories (errors=%d warnings=%d info=%d)\n",
+		len(r.Findings), r.TotalStories, r.Counts.Error, r.Counts.Warn, r.Counts.Info)
+	if r.Scope != "" {
+		fmt.Fprintf(w, "scope: %s\n", r.Scope)
+	}
+	for _, f := range r.Findings {
+		fmt.Fprintf(w, "  [%s] %s: %s\n", f.Severity, f.Kind, f.Message)
+		if f.SuggestedFix != "" {
+			fmt.Fprintf(w, "      fix: %s\n", f.SuggestedFix)
+		}
+	}
+}

--- a/cmd/sprint_validate_deps_test.go
+++ b/cmd/sprint_validate_deps_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestSprintValidateDeps_CleanText runs the cobra command end-to-end on a
+// clean DAG fixture (single epic, linear chain → no findings) and asserts
+// the success path emits an "OK" line on stdout. The success path never
+// calls os.Exit(), so cobra Execute returns nil normally.
+func TestSprintValidateDeps_CleanText(t *testing.T) {
+	dir := t.TempDir()
+	epics := filepath.Join(dir, "epics.md")
+	if err := os.WriteFile(epics, []byte(`## Epic 1: Slice 0a — Reference
+
+### Story 1.1: Foo
+
+---
+story_id: "1.1"
+---
+
+### Story 1.2: Bar
+
+---
+story_id: "1.2"
+depends_on: ["1.1"]
+---
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "validate-deps", "--epics", epics, "--no-log"})
+
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in clean text output, got:\n%s", out)
+	}
+}
+
+// TestSprintValidateDeps_JSONEnvelope asserts the --json wire shape for the
+// success path. We use a clean fixture so the command's blocking-exit branch
+// (which calls os.Exit(30) and would terminate the test process) is never
+// taken. The blocking-exit + counts behaviour is unit-tested in
+// application/sprint/validate_test.go via HasBlockingFindings(), so this
+// test only needs to cover the envelope wrapper.
+func TestSprintValidateDeps_JSONEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	epics := filepath.Join(dir, "clean.md")
+	if err := os.WriteFile(epics, []byte(`### Story 1.1: Only
+
+---
+story_id: "1.1"
+---
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "validate-deps", "--epics", epics, "--no-log", "--json"})
+
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	// Envelope shape mirrors cmd/jsonout.go's jsonEnvelope contract. We
+	// duplicate the struct rather than importing the private type, so a
+	// breaking rename of those fields is forced to update this assertion
+	// as a tripwire.
+	type envelope struct {
+		SchemaVersion string `json:"schema_version"`
+		Command       string `json:"command"`
+		Result        struct {
+			Findings []struct {
+				Kind     string `json:"kind"`
+				Severity string `json:"severity"`
+			} `json:"findings"`
+			Counts struct {
+				Error int `json:"error"`
+				Warn  int `json:"warn"`
+				Info  int `json:"info"`
+			} `json:"counts"`
+			Scope        string `json:"scope,omitempty"`
+			Strict       bool   `json:"strict"`
+			TotalStories int    `json:"total_stories"`
+		} `json:"result"`
+	}
+
+	var env envelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("envelope JSON parse failed: %v\nstdout:\n%s", err, out)
+	}
+	if env.SchemaVersion != "v1" {
+		t.Errorf("schema_version = %q, want v1", env.SchemaVersion)
+	}
+	if env.Command != "sprint validate-deps" {
+		t.Errorf("command field = %q, want %q", env.Command, "sprint validate-deps")
+	}
+	if total := env.Result.Counts.Error + env.Result.Counts.Warn + env.Result.Counts.Info; total != 0 {
+		t.Errorf("clean fixture should have zero counts, got %+v", env.Result.Counts)
+	}
+	if env.Result.TotalStories != 1 {
+		t.Errorf("total_stories = %d, want 1", env.Result.TotalStories)
+	}
+}
+
+// Verify the command registers under the cobra `sprint` namespace so the
+// help surface (and `bmad --help-json`) discovers it. The help surface is
+// part of the AI-agent ergonomic contract introduced in #38.
+func TestSprintValidateDeps_RegisteredInTree(t *testing.T) {
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+	root := NewRootCmd(zap.NewNop())
+	found := false
+	for _, c := range root.Commands() {
+		if c.Name() != "sprint" {
+			continue
+		}
+		for _, sub := range c.Commands() {
+			if sub.Name() == "validate-deps" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("validate-deps not registered under sprint command tree")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `bmad sprint validate-deps [--scope N] [--strict]`, a pure-Go static
analyser over the epics.md dependency graph. Five finding kinds, mapped to
the bmad-cli stable exit-code contract:

| Finding | Severity | Default exit |
|---|---|---|
| `cycle` | ERROR | 30 |
| `missing_dep` | ERROR | 30 |
| `orphan` | WARN | 0 (`--strict` → 30) |
| `placeholder_smell` | INFO | 0 |
| `diamond` | INFO | 0 |

JSON envelope v1 is emitted under `--json` with `findings[]` + `counts{error,warn,info}`.

## Acceptance criteria (issue #48)

- [x] Clean DAG → exit 0 + empty findings
- [x] Cycle fixture → exit 30 with the cycle path listed
- [x] Orphan fixture → exit 0 (WARN); `--strict` → exit 30
- [x] Non-existent ID reference → exit 30
- [x] Placeholder-smell → exit 0 (INFO) with suggested-fix referencing `docs/architecture/eda-cutover/saga-to-slice-mapping*.md`
- [x] Envelope v1 conforms (mirrors `bmad sprint plan --json` shape)
- [x] 6 synthetic fixtures + clean baseline (10 unit tests in `application/sprint/validate_test.go`)

## Coordination with bmad-cli #46

The placeholder-smell detector accepts an optional `EpicRequires map[string][]string`
that suppresses the finding when the operator has declared an explicit
`requires_epics:` at the epic header. Until #46 lands the cobra wrapper passes
`nil` (every linear-chain pattern flags); the single line to wire it in is
marked with a TODO comment in `cmd/sprint_validate_deps.go`.

## Files

- `application/sprint/validate.go` — pure validator (zero IO, zero DB)
- `cmd/sprint_validate_deps.go` — cobra adapter + exit-code mapping
- `application/sprint/validate_test.go` — 10 synthetic fixture tests
- `cmd/sprint_validate_deps_test.go` — cobra wiring + envelope shape
- `cmd/sprint.go` — register the new subcommand
- `README.md` — surface `validate-deps` in the command index

## SOLID notes

- SRP: each finding kind owns its own detector function.
- OCP: adding a new finding = add a detector + append to `Validate`'s pipeline.
- DIP: validator operates on `[]ParsedStory` (same canonical view `sprint plan` consumes).
- ISP: `ValidateOptions` struct keeps additive options from breaking callers.
- Cycle detection is iterative three-color DFS with canonical-rotation dedup
  so the same cycle reaches only one finding regardless of DFS entry point.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -short ./...` green (10/10 validator tests + 3 cobra tests)
- [x] Smoke-tested the binary against clean / cycle / placeholder fixtures
  and confirmed exit codes (0 / 30 / 0) and envelope shape
- [ ] CI confirms on PR