### PR TITLE
feat(state): hydration-priority sort in `story next` (closes #49)

### DIFF
--- a/application/state/story.go
+++ b/application/state/story.go
@@ -31,6 +31,20 @@ type NextAction struct {
 	Affects    []string `json:"affects"`
 }
 
+// NextOptions tunes the candidate sort used by NextWithOptions. Zero value
+// is the production default: scope-unfiltered, hydration-priority on.
+type NextOptions struct {
+	// Scope is the optional --scope <epic-id> per-call filter (issue #35).
+	// Empty = no filter.
+	Scope string
+	// NoHydrationPriority opts out of the issue-#49 hydration-priority
+	// bucket sort. When false (the default), candidates whose
+	// hydrated_file is non-nil drain first. When true, the legacy
+	// dep-order-only behaviour is restored — useful for the rare
+	// operator override "I explicitly want a fresh story now."
+	NoHydrationPriority bool
+}
+
 // Next returns up to max stories that are unblocked AND non-overlapping in
 // `affects` paths (file-overlap detection from §12 / sprint planning).
 //
@@ -57,7 +71,28 @@ func (s *StoryService) Next(ctx context.Context, max int) ([]NextAction, error) 
 // A scope that matches zero stories returns an empty batch (no error).
 // That mirrors the "nothing dispatchable right now" shape callers already
 // handle for the unscoped case.
+//
+// Equivalent to NextWithOptions(ctx, max, NextOptions{Scope: scope}).
 func (s *StoryService) NextWithScope(ctx context.Context, max int, scope string) ([]NextAction, error) {
+	return s.NextWithOptions(ctx, max, NextOptions{Scope: scope})
+}
+
+// NextWithOptions is the full-fidelity entry point. Scope filter is applied
+// to the candidate set BEFORE the hydration-priority sort, so a tightly
+// scoped call still drains hydrated-pending first within that scope.
+//
+// Hydration-priority sort (issue #49) reorders the candidates produced by
+// Stories.List (which already emits ORDER BY id, giving us the dep-order +
+// id-ordinal tiebreaker for free) into two buckets:
+//
+//  1. hydrated_file IS NOT NULL AND status = pending  (drain first)
+//  2. everything else                                 (fresh)
+//
+// The partition is stable, so within each bucket the existing dep-order +
+// id-ordinal sort is preserved. The reaper that runs in `cmd/story.go`
+// before NextWithOptions is invoked is unaffected — this method touches
+// the in-memory candidate slice only, never claim metadata or status.
+func (s *StoryService) NextWithOptions(ctx context.Context, max int, opts NextOptions) ([]NextAction, error) {
 	if max <= 0 {
 		max = s.effectiveMaxParallel(ctx)
 	}
@@ -66,6 +101,10 @@ func (s *StoryService) NextWithScope(ctx context.Context, max int, scope string)
 	candidates, err := s.Stories.List(ctx, state.StoryFilter{Status: &pending})
 	if err != nil {
 		return nil, fmt.Errorf("story next list pending: %w", err)
+	}
+
+	if !opts.NoHydrationPriority {
+		candidates = sortHydrationPriority(candidates)
 	}
 
 	var out []NextAction
@@ -77,7 +116,7 @@ func (s *StoryService) NextWithScope(ctx context.Context, max int, scope string)
 		}
 		// --scope filter — apply BEFORE the (more expensive) deps + affects
 		// lookups so a tightly-scoped call short-circuits cleanly.
-		if !appsprint.StoryMatchesEpic(st.ID, scope) {
+		if !appsprint.StoryMatchesEpic(st.ID, opts.Scope) {
 			continue
 		}
 		ok, err := s.depsSatisfied(ctx, st.ID)
@@ -113,6 +152,31 @@ func (s *StoryService) NextWithScope(ctx context.Context, max int, scope string)
 		})
 	}
 	return out, nil
+}
+
+// sortHydrationPriority returns a new slice with hydrated-pending stories
+// emitted first (in their original relative order), then the rest. Stable
+// — preserves the dep-order + id-ordinal sort that Stories.List already
+// applies. Pure function, no I/O, easy to test in isolation.
+func sortHydrationPriority(in []state.Story) []state.Story {
+	if len(in) < 2 {
+		return in
+	}
+	out := make([]state.Story, 0, len(in))
+	// Pass 1: hydrated-pending bucket.
+	for _, st := range in {
+		if st.HydratedFile != nil && st.Status == state.StatusPending {
+			out = append(out, st)
+		}
+	}
+	// Pass 2: everything else, preserving order.
+	for _, st := range in {
+		if st.HydratedFile != nil && st.Status == state.StatusPending {
+			continue
+		}
+		out = append(out, st)
+	}
+	return out
 }
 
 func (s *StoryService) depsSatisfied(ctx context.Context, storyID string) (bool, error) {

--- a/application/state/story_test.go
+++ b/application/state/story_test.go
@@ -175,6 +175,105 @@ func TestStoryNext_EmptyScopeEquivalentToNext(t *testing.T) {
 	}
 }
 
+// TestStoryNext_HydrationPriorityDrainsFirst — issue #49 AC #1, #3.
+// Mixed fixture: 2 fresh-pending + 2 hydrated-pending, max_parallel = 4.
+// Default sort must emit the two hydrated-pending rows FIRST (in their
+// natural id-ordinal order), then the two fresh rows. This prevents the
+// orchestrator from re-paying the hydrate token cost after a restart.
+func TestStoryNext_HydrationPriorityDrainsFirst(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	// Seed order is deliberately scrambled vs id-ordinal to prove the
+	// sort is driven by hydrated-file presence, not insertion order.
+	seed(t, svc, "1.1", state.StatusPending) // fresh
+	seed(t, svc, "1.3", state.StatusPending) // hydrated
+	seed(t, svc, "1.2", state.StatusPending) // fresh
+	seed(t, svc, "1.4", state.StatusPending) // hydrated
+	if err := svc.Stories.SetHydratedFile(ctx, "1.3", "stories/1.3.hydrated.md", false); err != nil {
+		t.Fatalf("SetHydratedFile 1.3: %v", err)
+	}
+	if err := svc.Stories.SetHydratedFile(ctx, "1.4", "stories/1.4.hydrated.md", false); err != nil {
+		t.Fatalf("SetHydratedFile 1.4: %v", err)
+	}
+
+	out, err := svc.Next(ctx, 4)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if len(out) != 4 {
+		t.Fatalf("Next len = %d, want 4", len(out))
+	}
+	gotIDs := []string{out[0].StoryID, out[1].StoryID, out[2].StoryID, out[3].StoryID}
+	wantIDs := []string{"1.3", "1.4", "1.1", "1.2"}
+	for i, want := range wantIDs {
+		if gotIDs[i] != want {
+			t.Fatalf("Next order = %v, want %v (hydrated-pending must drain first)", gotIDs, wantIDs)
+		}
+	}
+}
+
+// TestStoryNext_NoHydrationPriorityFlag — issue #49 AC #2. Passing
+// NoHydrationPriority=true must restore the legacy dep-order-only sort
+// (Stories.List ORDER BY id), i.e. 1.1 ahead of 1.3 even though 1.3 is
+// hydrated.
+func TestStoryNext_NoHydrationPriorityFlag(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	seed(t, svc, "1.1", state.StatusPending) // fresh
+	seed(t, svc, "1.3", state.StatusPending) // hydrated
+	seed(t, svc, "1.2", state.StatusPending) // fresh
+	if err := svc.Stories.SetHydratedFile(ctx, "1.3", "stories/1.3.hydrated.md", false); err != nil {
+		t.Fatalf("SetHydratedFile: %v", err)
+	}
+
+	out, err := svc.NextWithOptions(ctx, 3, appstate.NextOptions{NoHydrationPriority: true})
+	if err != nil {
+		t.Fatalf("NextWithOptions: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3", len(out))
+	}
+	wantIDs := []string{"1.1", "1.2", "1.3"}
+	for i, want := range wantIDs {
+		if out[i].StoryID != want {
+			t.Fatalf("NoHydrationPriority order = %+v, want %v (legacy dep-order)", out, wantIDs)
+		}
+	}
+}
+
+// TestStoryNext_HydrationPriorityRespectsDeps — issue #49 AC #4 (claim
+// atomicity is verified at the cmd layer + ClaimUnclaimedPending; here we
+// confirm the sort never widens the candidate set past the deps gate.
+// A hydrated-pending story whose dep is still pending must still be held
+// back — hydration-priority is a tiebreaker among UNBLOCKED candidates,
+// not a way to jump the queue.
+func TestStoryNext_HydrationPriorityRespectsDeps(t *testing.T) {
+	t.Parallel()
+	svc, _ := newStoryService(t)
+	ctx := context.Background()
+
+	seed(t, svc, "1.1", state.StatusPending) // fresh, no deps
+	seed(t, svc, "1.2", state.StatusPending) // hydrated, blocked on 1.1
+	if err := svc.Stories.SetHydratedFile(ctx, "1.2", "stories/1.2.hydrated.md", false); err != nil {
+		t.Fatalf("SetHydratedFile: %v", err)
+	}
+	_ = svc.Dependencies.Add(ctx, "1.2", "1.1")
+
+	out, err := svc.Next(ctx, 4)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	// 1.2 is hydrated but blocked → must NOT appear; 1.1 is the only
+	// eligible row.
+	if len(out) != 1 || out[0].StoryID != "1.1" {
+		t.Fatalf("Next = %+v, want [1.1] only (1.2 blocked by 1.1 even though hydrated)", out)
+	}
+}
+
 func TestNext_FileOverlapPreventsParallelism(t *testing.T) {
 	t.Parallel()
 	svc, _ := newStoryService(t)

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -253,10 +253,11 @@ agent returns produces the same instruction.`,
 
 func newStoryNextCmd() *cobra.Command {
 	var (
-		max     int
-		claim   bool
-		claimer string
-		scope   string
+		max                 int
+		claim               bool
+		claimer             string
+		scope               string
+		noHydrationPriority bool
 	)
 	cmd := &cobra.Command{
 		Use:   "next",
@@ -280,7 +281,15 @@ candidate set to stories whose id matches the epic (e.g. --scope 2 →
 only 2.* stories; --scope 10 will NOT match 1.* — uses the same
 prefix+dot rule as ` + "`bmad sprint plan --scope`" + `). The filter is
 applied to candidates BEFORE pick, never mutates state, and an empty
-match returns an empty batch (exit 0), not an error.`,
+match returns an empty batch (exit 0), not an error.
+
+Hydration-priority sort (issue #49): by default, candidates whose
+hydrated_file is non-nil drain BEFORE fresh stories — preserving the
+~80-100k token hydrate cost across orchestrator session restarts
+(skill updates, sprint checkpoints, worktree restores). The
+dep-order + id-ordinal tiebreaker is preserved within each bucket.
+Pass --no-hydration-priority to revert to the legacy dep-order-only
+behaviour (the rare "I explicitly want fresh now" override).`,
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
 			svc, cleanup, err := openStoryService(ctx)
@@ -309,7 +318,10 @@ match returns an empty batch (exit 0), not an error.`,
 					id, ttl)
 			}
 
-			actions, err := svc.NextWithScope(ctx, max, scope)
+			actions, err := svc.NextWithOptions(ctx, max, appstate.NextOptions{
+				Scope:               scope,
+				NoHydrationPriority: noHydrationPriority,
+			})
 			if err != nil {
 				return err
 			}
@@ -375,6 +387,8 @@ match returns an empty batch (exit 0), not an error.`,
 	cmd.Flags().BoolVar(&claim, "claim", true, "atomically claim returned stories (set claimed_at + claimed_by)")
 	cmd.Flags().StringVar(&claimer, "claimer", "orchestrator", "claimed_by value (e.g. session id)")
 	cmd.Flags().StringVar(&scope, "scope", "", "restrict candidates to one epic id (e.g. 2 → only 2.* stories; empty = no filter)")
+	cmd.Flags().BoolVar(&noHydrationPriority, "no-hydration-priority", false,
+		"opt out of issue-#49 hydration-priority bucket sort (default: hydrated-pending stories drain first to avoid re-paying ~80-100k token hydrate cost on session restarts)")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

- `bmad story next` candidate sort now drains **hydrated-pending stories first** before fresh ones — protects the ~80-100k token hydrate cost across orchestrator session restarts (skill updates, sprint checkpoints, worktree restores).
- Stable two-pass partition via new pure `sortHydrationPriority(in []state.Story)` helper. `Stories.List` already emits `ORDER BY id`, so dep-order + id-ordinal tiebreaker is preserved within each bucket for free.
- New `NextOptions{Scope, NoHydrationPriority}` struct + `StoryService.NextWithOptions(ctx, max, opts)` entry point. `NextWithScope` delegates to it; `Next` continues delegating via `NextWithScope`. Source-compatible.
- `--no-hydration-priority` flag on `bmad story next` for the rare operator override (AC #2).

## Invariants preserved

- **--claim atomicity (AC #4)**: reorder is in-memory before `ClaimUnclaimedPending`. Pick→claim transaction unchanged.
- **Stale-claim reaper (AC #5)**: still runs in `cmd/story.go` BEFORE `NextWithOptions` is invoked. This change does not touch claim metadata or status.
- **Deps gate**: hydration-priority is a tiebreaker among ALREADY-unblocked candidates. A hydrated row whose dep is still pending stays held back.

## Changes

- `application/state/story.go` — `NextOptions`, `NextWithOptions`, `sortHydrationPriority` (pure, no I/O).
- `cmd/story.go` — `--no-hydration-priority` flag wired through `NextWithOptions`; help text updated.
- `application/state/story_test.go` — 3 new tests covering AC #1, #2, #3, #4 + the deps-gate invariant.

## Test plan

- [x] `go test ./application/state/...` — new tests pass:
  - `TestStoryNext_HydrationPriorityDrainsFirst` (AC #1, #3)
  - `TestStoryNext_NoHydrationPriorityFlag` (AC #2)
  - `TestStoryNext_HydrationPriorityRespectsDeps` (AC #4 + deps gate)
- [x] `go test ./cmd/... ./application/state/... ./infrastructure/... ./domain/...` — all green
- [x] `go build ./...` — clean
- Note: `application/sprint` package has a pre-existing panic on `main` in `TestBuildStoryContext_NutritionV2Go_Story49_HasCodeContext` (atlas v0.1.2 `AddAmbiguousEdge` panic inside `IndexProject`). Unrelated to this PR; reproduces on `main` at the same commit (`f5ca06c`).

Closes #49.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>