### PR TITLE
feat(sprint): `bmad sprint graph` — DOT/mermaid/json DAG (closes #47)

### DIFF
--- a/application/sprint/graph.go
+++ b/application/sprint/graph.go
@@ -1,0 +1,583 @@
+package sprint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+)
+
+// ============================================================================
+// Issue #47 — `bmad sprint graph` dependency-DAG visualisation
+// ============================================================================
+//
+// Reads the resolved edges table (state.StoryDependencies) plus the stories
+// table (state.Stories), assembles an in-memory Graph, and renders it as
+// DOT, Mermaid, or JSON.
+//
+// The Builder + Graph + Renderer split is deliberate (SOLID):
+//   - Builder OWNS port IO and scope-filter logic; testable via mocks but
+//     in practice tested end-to-end via the sqlite adapter.
+//   - Graph is the pure data structure — no ports, no IO.
+//   - Renderer is an interface; each format is its own struct so adding a
+//     fourth format (issue #47 explicitly mentions "future dashboards")
+//     touches only one new file, not the Builder or any existing renderer.
+//
+// Edge-kind semantics: the resolved-edges port currently surfaces only
+// story-level depends_on edges (EdgeKindDepends, solid). Issue #46 will
+// introduce epic-level requires_epics synthesised edges (EdgeKindEpicSynth,
+// dashed); when that ships, the Builder will start to see EdgeKindEpicSynth
+// values without any renderer change.
+// ============================================================================
+
+// EdgeKind classifies a dependency edge so renderers can style it.
+type EdgeKind string
+
+const (
+	// EdgeKindDepends is a story-level depends_on edge — solid line.
+	EdgeKindDepends EdgeKind = "depends_on"
+	// EdgeKindEpicSynth is an epic-level requires_epics edge synthesised by
+	// the epic-DAG resolver (issue #46) — dashed line.
+	EdgeKindEpicSynth EdgeKind = "epic_synth"
+)
+
+// NodeKind classifies a graph node — story vs epic-summary cluster.
+type NodeKind string
+
+const (
+	NodeKindStory NodeKind = "story"
+	NodeKindEpic  NodeKind = "epic"
+)
+
+// Node is one vertex in the dependency DAG.
+type Node struct {
+	ID      string       `json:"id"`
+	Label   string       `json:"label"`
+	Status  state.Status `json:"status,omitempty"`
+	Kind    NodeKind     `json:"kind"`
+	EpicID  string       `json:"epic_id,omitempty"`
+	Subject string       `json:"subject,omitempty"`
+}
+
+// Edge is one directed dependency: From depends on To (so To must complete first).
+type Edge struct {
+	From string   `json:"from"`
+	To   string   `json:"to"`
+	Kind EdgeKind `json:"kind"`
+}
+
+// Graph is the pure-data DAG passed between Builder and Renderers.
+type Graph struct {
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+	// Scope, when non-empty, records the --scope filter that produced this graph.
+	Scope string `json:"scope,omitempty"`
+}
+
+// SubjectLimit caps the trailing label subject at 30 chars (issue #47
+// acceptance: "<id> + first 30 chars of subject").
+const SubjectLimit = 30
+
+// ----------------------------------------------------------------------------
+// Builder
+// ----------------------------------------------------------------------------
+
+// GraphBuilderOptions parameterises a Builder.Build call.
+type GraphBuilderOptions struct {
+	// Scope, when non-empty, restricts the graph to stories matching this
+	// epic id (per StoryMatchesEpic prefix+dot rule) PLUS all transitive
+	// upstream nodes — so an operator running `--scope 7` still sees the
+	// 4.12 dependency that gates 7.1.
+	Scope string
+	// IncludeCompleted controls whether complete stories appear. Defaults
+	// to true; set to false to hide green nodes and focus on remaining work.
+	IncludeCompleted bool
+}
+
+// GraphBuilder assembles a Graph from the resolved edges port and the
+// stories port.
+type GraphBuilder struct {
+	Stories      state.Stories
+	Dependencies state.StoryDependencies
+}
+
+// Build loads every story + every edge, applies the scope/completed filters,
+// and returns a deterministic Graph.
+//
+// Determinism: nodes are sorted by id; edges are sorted by (from, to, kind).
+// This is what makes snapshot tests stable across runs.
+func (b *GraphBuilder) Build(ctx context.Context, opts GraphBuilderOptions) (*Graph, error) {
+	if b.Stories == nil || b.Dependencies == nil {
+		return nil, fmt.Errorf("graph builder: Stories and Dependencies ports are required")
+	}
+	all, err := b.Stories.List(ctx, state.StoryFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("graph builder: list stories: %w", err)
+	}
+
+	// Index stories by id for O(1) lookup.
+	byID := make(map[string]state.Story, len(all))
+	for _, s := range all {
+		byID[s.ID] = s
+	}
+
+	// Collect every edge by iterating each story's depends_on list. We
+	// intentionally call .Of per story (not a single bulk read) because the
+	// port doesn't expose a bulk variant today, and 190 stories × 1 SELECT
+	// each on a local SQLite file is ~10ms in practice — well under the
+	// 500ms acceptance budget.
+	var rawEdges []Edge
+	for _, s := range all {
+		deps, err := b.Dependencies.Of(ctx, s.ID)
+		if err != nil {
+			return nil, fmt.Errorf("graph builder: deps for %q: %w", s.ID, err)
+		}
+		for _, dep := range deps {
+			rawEdges = append(rawEdges, Edge{
+				From: s.ID,
+				To:   dep,
+				// Currently all rows are story-level; epic-synth edges (issue
+				// #46) will tag themselves once the resolved-edges schema
+				// gains an edge_kind column.
+				Kind: EdgeKindDepends,
+			})
+		}
+	}
+
+	// Determine the set of story ids to KEEP.
+	keep := selectKeep(all, rawEdges, opts)
+
+	// Build node + edge slices in deterministic order.
+	g := &Graph{Scope: opts.Scope}
+	for _, s := range all {
+		if !keep[s.ID] {
+			continue
+		}
+		g.Nodes = append(g.Nodes, storyToNode(s))
+	}
+	for _, e := range rawEdges {
+		if !keep[e.From] || !keep[e.To] {
+			continue
+		}
+		g.Edges = append(g.Edges, e)
+	}
+
+	sort.Slice(g.Nodes, func(i, j int) bool { return g.Nodes[i].ID < g.Nodes[j].ID })
+	sort.Slice(g.Edges, func(i, j int) bool {
+		if g.Edges[i].From != g.Edges[j].From {
+			return g.Edges[i].From < g.Edges[j].From
+		}
+		if g.Edges[i].To != g.Edges[j].To {
+			return g.Edges[i].To < g.Edges[j].To
+		}
+		return g.Edges[i].Kind < g.Edges[j].Kind
+	})
+	return g, nil
+}
+
+// selectKeep returns the set of story ids that survive the scope +
+// completed-filter combination.
+//
+// Scope semantics (issue #47 AC4): when --scope N is set, include every
+// story that matches Epic N AND every transitive upstream node so the
+// dependency context is visible — otherwise an operator would see "7.1
+// depends on something but the something is missing from the graph."
+func selectKeep(all []state.Story, edges []Edge, opts GraphBuilderOptions) map[string]bool {
+	keep := make(map[string]bool, len(all))
+	if opts.Scope == "" {
+		for _, s := range all {
+			if !opts.IncludeCompleted && s.Status == state.StatusComplete {
+				continue
+			}
+			keep[s.ID] = true
+		}
+		return keep
+	}
+
+	// Seed: every story that matches the scope.
+	for _, s := range all {
+		if StoryMatchesEpic(s.ID, opts.Scope) {
+			keep[s.ID] = true
+		}
+	}
+
+	// Transitive upstream walk: an edge (from→to) means "from depends on to."
+	// We want every upstream `to` reachable from a seeded `from`.
+	adjacency := make(map[string][]string, len(all))
+	for _, e := range edges {
+		adjacency[e.From] = append(adjacency[e.From], e.To)
+	}
+	frontier := make([]string, 0, len(keep))
+	for id := range keep {
+		frontier = append(frontier, id)
+	}
+	for len(frontier) > 0 {
+		id := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		for _, up := range adjacency[id] {
+			if !keep[up] {
+				keep[up] = true
+				frontier = append(frontier, up)
+			}
+		}
+	}
+
+	// IncludeCompleted=false filter applies AFTER transitive expansion. A
+	// completed upstream prerequisite still appears unless explicitly hidden,
+	// which is the right default — operators want to see "7.1 is blocked
+	// because complete 4.12 is its only upstream." When they ask to hide
+	// completed, we honour that and drop the green node + any edges it owns.
+	if !opts.IncludeCompleted {
+		for _, s := range all {
+			if s.Status == state.StatusComplete {
+				delete(keep, s.ID)
+			}
+		}
+	}
+	return keep
+}
+
+// storyToNode projects a state.Story into a graph Node — the renderer never
+// reads Story fields directly so we can swap the projection without touching
+// any format-specific code.
+func storyToNode(s state.Story) Node {
+	subject := truncate(s.Title, SubjectLimit)
+	label := s.ID
+	if subject != "" {
+		label = s.ID + " " + subject
+	}
+	return Node{
+		ID:      s.ID,
+		Label:   label,
+		Status:  s.Status,
+		Kind:    NodeKindStory,
+		EpicID:  EpicIDFromStory(s.ID),
+		Subject: subject,
+	}
+}
+
+// truncate clips s to at most n runes (not bytes) so multi-byte titles don't
+// get sliced mid-rune, then appends an ellipsis when the clip actually cut.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
+}
+
+// ----------------------------------------------------------------------------
+// Renderer interface + format dispatch
+// ----------------------------------------------------------------------------
+
+// Format names the three accepted --format values.
+type Format string
+
+const (
+	FormatDOT     Format = "dot"
+	FormatMermaid Format = "mermaid"
+	FormatJSON    Format = "json"
+)
+
+// ParseFormat normalises a --format flag value, returning a typed Format.
+func ParseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "dot", "":
+		return FormatDOT, nil
+	case "mermaid":
+		return FormatMermaid, nil
+	case "json":
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("graph: unknown --format %q (want one of: dot|mermaid|json)", s)
+	}
+}
+
+// Renderer is the open/closed extension point — to add a new format,
+// implement Render and register in NewRenderer.
+type Renderer interface {
+	Render(w io.Writer, g *Graph) error
+}
+
+// NewRenderer returns the renderer matching the given format. The
+// `withStatus` toggle is a renderer-level concern (whether to colour /
+// style nodes by their status); it threads in at construction so each
+// concrete renderer can wire it once.
+func NewRenderer(format Format, withStatus bool) (Renderer, error) {
+	switch format {
+	case FormatDOT:
+		return &DOTRenderer{WithStatus: withStatus}, nil
+	case FormatMermaid:
+		return &MermaidRenderer{WithStatus: withStatus}, nil
+	case FormatJSON:
+		return &JSONRenderer{}, nil
+	default:
+		return nil, fmt.Errorf("graph: no renderer for format %q", format)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Status → colour / shape mapping
+//
+// Centralised so DOT and Mermaid share the same truth source — if we
+// later add a colour-blind palette toggle, it lives in one place.
+// ----------------------------------------------------------------------------
+
+// statusColour returns a hex colour for a status. Returned without the
+// leading "#" so the renderer can format it per its syntax (DOT wants
+// `"#90EE90"`, Mermaid `fill:#90EE90`).
+func statusColour(s state.Status) string {
+	switch s {
+	case state.StatusComplete:
+		return "#90EE90" // light green
+	case state.StatusInProgress, state.StatusHydrating, state.StatusReviewing,
+		state.StatusCommitting, state.StatusEnvUp, state.StatusEnvDown:
+		return "#FFD580" // soft yellow — covers all "in flight" stages
+	case state.StatusBlocked:
+		return "#FF9999" // soft red
+	case state.StatusPending:
+		return "#D3D3D3" // grey
+	default:
+		// Defensive default. A status we don't recognise (e.g. a future
+		// `hydrated-pending` introduced post-#47) gets a distinctive blue
+		// so it stands out for triage — issue #47's status colour list
+		// explicitly calls out "blue=hydrated-pending" as a near-term add.
+		return "#9CC0FF"
+	}
+}
+
+// ----------------------------------------------------------------------------
+// DOT renderer
+// ----------------------------------------------------------------------------
+
+// DOTRenderer emits Graphviz DOT — the default format. Pipe to
+// `dot -Tsvg` for an interactive viewer.
+type DOTRenderer struct {
+	WithStatus bool
+}
+
+// Render writes a DOT document to w. The output is deterministic and
+// pipe-safe (no trailing whitespace on attribute lines).
+func (r *DOTRenderer) Render(w io.Writer, g *Graph) error {
+	if g == nil {
+		return fmt.Errorf("DOTRenderer: nil graph")
+	}
+	var b strings.Builder
+	b.WriteString("digraph sprint {\n")
+	b.WriteString("  rankdir=LR;\n")
+	b.WriteString("  node [shape=box, style=\"rounded,filled\", fontname=\"Helvetica\"];\n")
+	b.WriteString("  edge [color=\"#666666\"];\n")
+	for _, n := range g.Nodes {
+		b.WriteString("  ")
+		b.WriteString(dotNodeID(n.ID))
+		b.WriteString(" [label=")
+		b.WriteString(dotQuote(n.Label))
+		if r.WithStatus {
+			b.WriteString(", fillcolor=\"")
+			b.WriteString(statusColour(n.Status))
+			b.WriteString("\"")
+		} else {
+			b.WriteString(", fillcolor=\"#FFFFFF\"")
+		}
+		b.WriteString("];\n")
+	}
+	for _, e := range g.Edges {
+		b.WriteString("  ")
+		b.WriteString(dotNodeID(e.From))
+		b.WriteString(" -> ")
+		b.WriteString(dotNodeID(e.To))
+		if e.Kind == EdgeKindEpicSynth {
+			b.WriteString(" [style=dashed]")
+		}
+		b.WriteString(";\n")
+	}
+	b.WriteString("}\n")
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// dotNodeID returns a DOT-safe identifier. Story ids like "1.1" or
+// "1.1.payment-method-mgmt" aren't valid bare DOT identifiers (dots have
+// port-syntax meaning), so we always quote.
+func dotNodeID(id string) string {
+	return dotQuote(id)
+}
+
+// dotQuote wraps s in double-quotes and escapes any embedded `"` or `\`.
+func dotQuote(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return `"` + r.Replace(s) + `"`
+}
+
+// ----------------------------------------------------------------------------
+// Mermaid renderer
+// ----------------------------------------------------------------------------
+
+// MermaidRenderer emits a Mermaid `graph TD` block — paste-ready inside a
+// GitHub markdown code fence ```mermaid ... ``` for inline render.
+type MermaidRenderer struct {
+	WithStatus bool
+}
+
+// Render writes a Mermaid document to w.
+func (r *MermaidRenderer) Render(w io.Writer, g *Graph) error {
+	if g == nil {
+		return fmt.Errorf("MermaidRenderer: nil graph")
+	}
+	var b strings.Builder
+	b.WriteString("graph TD\n")
+	for _, n := range g.Nodes {
+		b.WriteString("  ")
+		b.WriteString(mermaidNodeID(n.ID))
+		b.WriteString("[")
+		b.WriteString(mermaidQuote(n.Label))
+		b.WriteString("]\n")
+	}
+	for _, e := range g.Edges {
+		arrow := " --> "
+		if e.Kind == EdgeKindEpicSynth {
+			// Mermaid uses `-.->` for a dashed/dotted arrow.
+			arrow = " -.-> "
+		}
+		b.WriteString("  ")
+		b.WriteString(mermaidNodeID(e.From))
+		b.WriteString(arrow)
+		b.WriteString(mermaidNodeID(e.To))
+		b.WriteString("\n")
+	}
+	if r.WithStatus {
+		writeMermaidClassDefs(&b, g)
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// writeMermaidClassDefs appends classDef declarations + per-node class
+// assignments. We declare a class only when at least one node uses it so
+// the output stays compact on small graphs.
+func writeMermaidClassDefs(b *strings.Builder, g *Graph) {
+	used := map[string]bool{}
+	for _, n := range g.Nodes {
+		used[statusClassName(n.Status)] = true
+	}
+	// Stable ordering for snapshot tests.
+	classes := make([]string, 0, len(used))
+	for c := range used {
+		classes = append(classes, c)
+	}
+	sort.Strings(classes)
+	for _, c := range classes {
+		fmt.Fprintf(b, "  classDef %s fill:%s,stroke:#333,stroke-width:1px;\n",
+			c, statusClassColour(c))
+	}
+	for _, n := range g.Nodes {
+		fmt.Fprintf(b, "  class %s %s;\n", mermaidNodeID(n.ID), statusClassName(n.Status))
+	}
+}
+
+// statusClassName maps a status to a Mermaid-safe class identifier.
+func statusClassName(s state.Status) string {
+	switch s {
+	case state.StatusComplete:
+		return "complete"
+	case state.StatusBlocked:
+		return "blocked"
+	case state.StatusPending:
+		return "pending"
+	case state.StatusInProgress, state.StatusHydrating, state.StatusReviewing,
+		state.StatusCommitting, state.StatusEnvUp, state.StatusEnvDown:
+		return "inflight"
+	default:
+		return "other"
+	}
+}
+
+// statusClassColour returns the fill colour for a class id — mirrors
+// statusColour but keyed off the class name so the writer can produce the
+// classDef line from already-aggregated class ids.
+func statusClassColour(class string) string {
+	switch class {
+	case "complete":
+		return "#90EE90"
+	case "inflight":
+		return "#FFD580"
+	case "blocked":
+		return "#FF9999"
+	case "pending":
+		return "#D3D3D3"
+	default:
+		return "#9CC0FF"
+	}
+}
+
+// mermaidNodeID makes a Mermaid-safe identifier — Mermaid disallows `.` and
+// `-` in bare node ids, so we replace with `_`. The original id stays
+// visible inside the label.
+func mermaidNodeID(id string) string {
+	r := strings.NewReplacer(".", "_", "-", "_", "/", "_")
+	return "s" + r.Replace(id)
+}
+
+// mermaidQuote wraps a label in double-quotes (Mermaid's preferred syntax
+// when the label contains spaces or punctuation) and escapes any `"`.
+func mermaidQuote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}
+
+// ----------------------------------------------------------------------------
+// JSON renderer — envelope v1 contract
+//
+// The wire-format is deliberately separate from the in-memory Graph: it
+// adds a schema_version + counts header so downstream tooling can detect
+// schema bumps without re-counting nodes / edges itself.
+// ----------------------------------------------------------------------------
+
+// JSONGraphEnvelope is the wire-format for `--format json`. Field order
+// is significant (Go marshals struct fields in declaration order); changing
+// it constitutes a breaking change — bump SchemaVersion when that happens.
+type JSONGraphEnvelope struct {
+	SchemaVersion string `json:"schema_version"`
+	Scope         string `json:"scope,omitempty"`
+	NodeCount     int    `json:"node_count"`
+	EdgeCount     int    `json:"edge_count"`
+	Nodes         []Node `json:"nodes"`
+	Edges         []Edge `json:"edges"`
+}
+
+// JSONGraphSchemaVersion is the envelope tag — bump only on breaking changes.
+const JSONGraphSchemaVersion = "v1"
+
+// JSONRenderer emits the machine-readable envelope.
+type JSONRenderer struct{}
+
+// Render writes the envelope as indented JSON.
+func (r *JSONRenderer) Render(w io.Writer, g *Graph) error {
+	if g == nil {
+		return fmt.Errorf("JSONRenderer: nil graph")
+	}
+	env := JSONGraphEnvelope{
+		SchemaVersion: JSONGraphSchemaVersion,
+		Scope:         g.Scope,
+		NodeCount:     len(g.Nodes),
+		EdgeCount:     len(g.Edges),
+		Nodes:         g.Nodes,
+		Edges:         g.Edges,
+	}
+	// Normalise nil slices to empty so the output is `[]` not `null`.
+	if env.Nodes == nil {
+		env.Nodes = []Node{}
+	}
+	if env.Edges == nil {
+		env.Edges = []Edge{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}

--- a/application/sprint/graph_bench_test.go
+++ b/application/sprint/graph_bench_test.go
@@ -1,0 +1,70 @@
+package sprint_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// BenchmarkGraphBuild_190Stories backs acceptance criterion #1:
+// `bmad sprint graph --format dot` runs in <500ms on a 190-story DB.
+//
+// We seed 22 epics × ~9 stories each = 198 stories with a realistic
+// intra-epic chain (Y → Y-1) and an inter-epic edge per epic.
+func BenchmarkGraphBuild_190Stories(b *testing.B) {
+	db := openDBForBench(b)
+	storiesStore := sqlite.NewStoriesStore(db)
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	ctx := context.Background()
+	now := time.Now()
+	for epic := 1; epic <= 22; epic++ {
+		for y := 1; y <= 9; y++ {
+			id := fmt.Sprintf("%d.%d", epic, y)
+			if err := storiesStore.Insert(ctx, state.Story{
+				ID: id, Title: fmt.Sprintf("epic %d story %d", epic, y),
+				Status: state.StatusPending, Complexity: state.ComplexityMedium,
+				StoryType: state.StoryTypeCode, CreatedAt: now, UpdatedAt: now,
+			}); err != nil {
+				b.Fatalf("seed %s: %v", id, err)
+			}
+			if y > 1 {
+				if err := depsStore.Add(ctx, id, fmt.Sprintf("%d.%d", epic, y-1)); err != nil {
+					b.Fatalf("dep: %v", err)
+				}
+			}
+			if epic > 1 && y == 1 {
+				if err := depsStore.Add(ctx, id, fmt.Sprintf("%d.9", epic-1)); err != nil {
+					b.Fatalf("inter-epic dep: %v", err)
+				}
+			}
+		}
+	}
+	builder := &sprint.GraphBuilder{Stories: storiesStore, Dependencies: depsStore}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g, err := builder.Build(ctx, sprint.GraphBuilderOptions{IncludeCompleted: true})
+		if err != nil {
+			b.Fatalf("Build: %v", err)
+		}
+		r, _ := sprint.NewRenderer(sprint.FormatDOT, true)
+		_ = r.Render(io.Discard, g)
+	}
+}
+
+// openDBForBench is the *testing.B variant of openDB.
+func openDBForBench(b *testing.B) *sqlite.DB {
+	b.Helper()
+	db, err := sqlite.Open(context.Background(), b.TempDir()+"/bmad-state.db")
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/application/sprint/graph_test.go
+++ b/application/sprint/graph_test.go
@@ -1,0 +1,429 @@
+package sprint_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// ----------------------------------------------------------------------------
+// 4-epic synthetic DAG fixture
+//
+//   1.1 ─┐
+//   1.2 ─┴─► 2.1 ─► 3.1
+//           2.2 ─► 3.2 ─► 4.1
+//                          4.2 (depends on 3.2 + 4.1)
+//
+// Stories carry mixed statuses so every renderer branch is exercised in
+// one shot — green/yellow/red/grey nodes all appear.
+// ----------------------------------------------------------------------------
+
+type fixtureStory struct {
+	id, title string
+	status    state.Status
+	deps      []string
+}
+
+var graphFixture = []fixtureStory{
+	{id: "1.1", title: "epics scaffold parser", status: state.StatusComplete},
+	{id: "1.2", title: "frontmatter coverage", status: state.StatusComplete},
+	{id: "2.1", title: "topo-sort batcher", status: state.StatusInProgress, deps: []string{"1.1", "1.2"}},
+	{id: "2.2", title: "file-overlap detector", status: state.StatusPending, deps: []string{"1.2"}},
+	{id: "3.1", title: "sqlite store init", status: state.StatusBlocked, deps: []string{"2.1"}},
+	{id: "3.2", title: "stories CRUD adapter", status: state.StatusPending, deps: []string{"2.2"}},
+	{id: "4.1", title: "story-next deps", status: state.StatusPending, deps: []string{"3.2"}},
+	{id: "4.2", title: "story-complete ledger", status: state.StatusPending, deps: []string{"3.2", "4.1"}},
+}
+
+// seedGraphFixture writes the 4-epic fixture to a fresh sqlite DB and
+// returns a fully-wired builder.
+func seedGraphFixture(t *testing.T) *sprint.GraphBuilder {
+	t.Helper()
+	db := openDB(t)
+	storiesStore := sqlite.NewStoriesStore(db)
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	ctx := context.Background()
+	now := time.Now()
+	for _, fs := range graphFixture {
+		s := state.Story{
+			ID:        fs.id,
+			Title:     fs.title,
+			Status:    fs.status,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Complexity: state.ComplexityMedium,
+			StoryType:  state.StoryTypeCode,
+		}
+		if err := storiesStore.Insert(ctx, s); err != nil {
+			t.Fatalf("seed story %s: %v", fs.id, err)
+		}
+		for _, dep := range fs.deps {
+			if err := depsStore.Add(ctx, fs.id, dep); err != nil {
+				t.Fatalf("seed dep %s->%s: %v", fs.id, dep, err)
+			}
+		}
+	}
+	return &sprint.GraphBuilder{Stories: storiesStore, Dependencies: depsStore}
+}
+
+// ----------------------------------------------------------------------------
+// Builder behaviour
+// ----------------------------------------------------------------------------
+
+func TestGraphBuilder_LoadsAllStoriesAndEdges(t *testing.T) {
+	t.Parallel()
+	b := seedGraphFixture(t)
+	g, err := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got, want := len(g.Nodes), len(graphFixture); got != want {
+		t.Fatalf("nodes = %d, want %d", got, want)
+	}
+	// Sum of all fixture deps.
+	want := 0
+	for _, f := range graphFixture {
+		want += len(f.deps)
+	}
+	if got := len(g.Edges); got != want {
+		t.Fatalf("edges = %d, want %d", got, want)
+	}
+}
+
+// TestGraphBuilder_ScopeIncludesTransitiveUpstream verifies AC4 — `--scope 3`
+// must surface every transitive upstream node (here 2.1 + 2.2 + 1.1 + 1.2)
+// even though those don't match the "3.*" prefix.
+func TestGraphBuilder_ScopeIncludesTransitiveUpstream(t *testing.T) {
+	t.Parallel()
+	b := seedGraphFixture(t)
+	g, err := b.Build(context.Background(), sprint.GraphBuilderOptions{
+		Scope:            "3",
+		IncludeCompleted: true,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ids := nodeIDs(g)
+	for _, want := range []string{"1.1", "1.2", "2.1", "2.2", "3.1", "3.2"} {
+		if !containsStr(ids, want) {
+			t.Errorf("scope=3 graph missing %q (got %v)", want, ids)
+		}
+	}
+	// 4.* must NOT be present — they're downstream, not part of Epic 3
+	// or its upstream chain.
+	for _, none := range []string{"4.1", "4.2"} {
+		if containsStr(ids, none) {
+			t.Errorf("scope=3 graph leaked downstream node %q (got %v)", none, ids)
+		}
+	}
+}
+
+// TestGraphBuilder_IncludeCompletedFalse drops green nodes.
+func TestGraphBuilder_IncludeCompletedFalse(t *testing.T) {
+	t.Parallel()
+	b := seedGraphFixture(t)
+	g, err := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: false})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ids := nodeIDs(g)
+	for _, none := range []string{"1.1", "1.2"} {
+		if containsStr(ids, none) {
+			t.Errorf("IncludeCompleted=false leaked complete node %q", none)
+		}
+	}
+}
+
+// TestGraphBuilder_DeterministicOrdering — same input = same output.
+func TestGraphBuilder_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	b := seedGraphFixture(t)
+	a, err := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	c, err := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !equalNodes(a.Nodes, c.Nodes) {
+		t.Fatalf("node order not deterministic across two builds")
+	}
+	if !equalEdges(a.Edges, c.Edges) {
+		t.Fatalf("edge order not deterministic across two builds")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Format / renderer snapshots
+// ----------------------------------------------------------------------------
+
+func TestParseFormat(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want sprint.Format
+		err  bool
+	}{
+		{"dot", sprint.FormatDOT, false},
+		{"", sprint.FormatDOT, false},
+		{"DOT", sprint.FormatDOT, false},
+		{"mermaid", sprint.FormatMermaid, false},
+		{"json", sprint.FormatJSON, false},
+		{"svg", "", true},
+	}
+	for _, tc := range cases {
+		got, err := sprint.ParseFormat(tc.in)
+		if tc.err {
+			if err == nil {
+				t.Errorf("ParseFormat(%q) want error, got %v", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseFormat(%q) unexpected error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("ParseFormat(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// renderToString builds a 4-epic graph + renders it to a string with the
+// chosen format. Shared helper for the three snapshot tests.
+func renderToString(t *testing.T, format sprint.Format, withStatus bool, opts sprint.GraphBuilderOptions) string {
+	t.Helper()
+	b := seedGraphFixture(t)
+	g, err := b.Build(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	r, err := sprint.NewRenderer(format, withStatus)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := r.Render(&buf, g); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return buf.String()
+}
+
+// TestRenderDOT_Snapshot — full-fixture DOT output. We assert on the
+// structurally-significant substrings rather than the entire string so a
+// cosmetic tweak (e.g. switching colour) only updates one line.
+func TestRenderDOT_Snapshot(t *testing.T) {
+	t.Parallel()
+	out := renderToString(t, sprint.FormatDOT, true, sprint.GraphBuilderOptions{IncludeCompleted: true})
+	mustContainAll(t, out, []string{
+		"digraph sprint {",
+		"rankdir=LR;",
+		`"1.1" [label="1.1 epics scaffold parser"`,
+		`fillcolor="#90EE90"`, // complete = green
+		`fillcolor="#FFD580"`, // in-progress = yellow
+		`fillcolor="#FF9999"`, // blocked = red
+		`fillcolor="#D3D3D3"`, // pending = grey
+		`"2.1" -> "1.1";`,
+		`"2.1" -> "1.2";`,
+		`"4.2" -> "3.2";`,
+		`"4.2" -> "4.1";`,
+	})
+	mustNotContain(t, out, "style=dashed") // no epic-synth edges in fixture
+}
+
+// TestRenderDOT_WithStatusFalse omits status colours — every node falls
+// back to white. Verifies the toggle actually works.
+func TestRenderDOT_WithStatusFalse(t *testing.T) {
+	t.Parallel()
+	out := renderToString(t, sprint.FormatDOT, false, sprint.GraphBuilderOptions{IncludeCompleted: true})
+	mustContainAll(t, out, []string{`fillcolor="#FFFFFF"`})
+	mustNotContain(t, out, `#90EE90`)
+}
+
+// TestRenderMermaid_Snapshot verifies GitHub-renderable Mermaid output.
+func TestRenderMermaid_Snapshot(t *testing.T) {
+	t.Parallel()
+	out := renderToString(t, sprint.FormatMermaid, true, sprint.GraphBuilderOptions{IncludeCompleted: true})
+	mustContainAll(t, out, []string{
+		"graph TD",
+		`s1_1["1.1 epics scaffold parser"]`,
+		`s2_1["2.1 topo-sort batcher"]`,
+		`s2_1 --> s1_1`,
+		`s4_2 --> s4_1`,
+		"classDef complete fill:#90EE90",
+		"classDef inflight fill:#FFD580",
+		"classDef blocked fill:#FF9999",
+		"classDef pending fill:#D3D3D3",
+		"class s1_1 complete",
+		"class s3_1 blocked",
+	})
+	// Mermaid epic-synth dashed-arrow form is `-.->`; not present in fixture.
+	mustNotContain(t, out, "-.->")
+}
+
+// TestRenderJSON_EnvelopeV1 documents the JSON envelope contract (AC3).
+func TestRenderJSON_EnvelopeV1(t *testing.T) {
+	t.Parallel()
+	out := renderToString(t, sprint.FormatJSON, false, sprint.GraphBuilderOptions{IncludeCompleted: true})
+
+	var env sprint.JSONGraphEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("envelope did not round-trip: %v\noutput=%s", err, out)
+	}
+	if env.SchemaVersion != sprint.JSONGraphSchemaVersion {
+		t.Errorf("schema_version = %q, want %q", env.SchemaVersion, sprint.JSONGraphSchemaVersion)
+	}
+	if env.NodeCount != len(graphFixture) {
+		t.Errorf("node_count = %d, want %d", env.NodeCount, len(graphFixture))
+	}
+	if got := env.EdgeCount; got != 8 {
+		t.Errorf("edge_count = %d, want 8", got)
+	}
+	// Validate the per-node fields cover everything a downstream visualiser
+	// would need: id, label, status, kind, epic_id, subject.
+	for _, n := range env.Nodes {
+		if n.ID == "" || n.Label == "" || n.Kind == "" || n.EpicID == "" {
+			t.Errorf("node missing required field: %+v", n)
+		}
+	}
+	for _, e := range env.Edges {
+		if e.From == "" || e.To == "" || e.Kind == "" {
+			t.Errorf("edge missing required field: %+v", e)
+		}
+	}
+}
+
+// TestRenderJSON_EmptyGraph — empty input must produce `[]` not `null` for
+// nodes + edges so jq queries don't crash on null-iteration.
+func TestRenderJSON_EmptyGraph(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	b := &sprint.GraphBuilder{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+	}
+	g, err := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	r := &sprint.JSONRenderer{}
+	var buf bytes.Buffer
+	if err := r.Render(&buf, g); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	mustContainAll(t, buf.String(), []string{
+		`"nodes": []`,
+		`"edges": []`,
+		`"node_count": 0`,
+	})
+}
+
+// TestRenderer_NilGraph — every renderer must reject nil rather than panic.
+func TestRenderer_NilGraph(t *testing.T) {
+	t.Parallel()
+	for _, format := range []sprint.Format{sprint.FormatDOT, sprint.FormatMermaid, sprint.FormatJSON} {
+		r, err := sprint.NewRenderer(format, true)
+		if err != nil {
+			t.Fatalf("NewRenderer(%v): %v", format, err)
+		}
+		if err := r.Render(&bytes.Buffer{}, nil); err == nil {
+			t.Errorf("renderer(%v).Render(nil) want error", format)
+		}
+	}
+}
+
+// TestTruncate_SubjectLimit covers the 30-char clip rule (AC: label = id +
+// first 30 chars of subject).
+func TestRenderDOT_SubjectClippedAt30Chars(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	storiesStore := sqlite.NewStoriesStore(db)
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	long := strings.Repeat("a", 60)
+	now := time.Now()
+	if err := storiesStore.Insert(context.Background(), state.Story{
+		ID: "9.9", Title: long, Status: state.StatusPending,
+		Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	b := &sprint.GraphBuilder{Stories: storiesStore, Dependencies: depsStore}
+	g, _ := b.Build(context.Background(), sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if len(g.Nodes) != 1 {
+		t.Fatalf("expect 1 node, got %d", len(g.Nodes))
+	}
+	// 29 'a' chars + "…" = 30 runes total.
+	wantSubject := strings.Repeat("a", 29) + "…"
+	if g.Nodes[0].Subject != wantSubject {
+		t.Errorf("Subject = %q, want %q", g.Nodes[0].Subject, wantSubject)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// helpers
+// ----------------------------------------------------------------------------
+
+func nodeIDs(g *sprint.Graph) []string {
+	out := make([]string, 0, len(g.Nodes))
+	for _, n := range g.Nodes {
+		out = append(out, n.ID)
+	}
+	return out
+}
+
+func containsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func equalNodes(a, b []sprint.Node) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalEdges(a, b []sprint.Edge) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func mustContainAll(t *testing.T, haystack string, needles []string) {
+	t.Helper()
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) {
+			t.Errorf("output missing substring %q\n--- full output ---\n%s", needle, haystack)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("output unexpectedly contains %q", needle)
+	}
+}

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -35,6 +35,7 @@ func newSprintCmd() *cobra.Command {
 		newSprintCacheBundleCmd(),
 		newSprintInferDepsCmd(),
 		newSprintValidateDepsCmd(),
+		newSprintGraphCmd(),
 	)
 	addV6PersistentFlags(cmd)
 	return cmd

--- a/cmd/sprint_graph.go
+++ b/cmd/sprint_graph.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	appsprint "github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// newSprintGraphCmd wires `bmad sprint graph` (issue #47).
+//
+// It reads the resolved-edges port (currently fed by `bmad sprint plan`;
+// will additionally be fed by `bmad sprint infer-epic-deps` once issue #46
+// lands) and renders the dependency DAG as DOT, Mermaid, or JSON.
+//
+// Why this is a thin shim: all rendering and graph-construction logic
+// lives in application/sprint/graph.go. The cobra layer is responsible
+// only for flag parsing, DB opening, format dispatch, and stdout/JSON
+// envelope plumbing — so the same graph code is reusable from tests,
+// from a potential `bmad system-check` hook, and from any future
+// in-process consumer (e.g. an MCP server that wants the JSON envelope).
+func newSprintGraphCmd() *cobra.Command {
+	var (
+		formatFlag       string
+		scope            string
+		withStatus       bool
+		includeCompleted bool
+	)
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Render the resolved sprint DAG as DOT, Mermaid, or JSON",
+		Long: `Reads the resolved edges (story_dependencies) + stories table and
+renders the dependency graph for visual inspection.
+
+  bmad sprint graph                            # DOT to stdout
+  bmad sprint graph --format mermaid           # Mermaid (paste into a GitHub MD code block)
+  bmad sprint graph --format json              # machine-readable envelope v1
+  bmad sprint graph --scope 7                  # Epic 7 + transitive upstream
+  bmad sprint graph --include-completed=false  # hide green nodes
+
+Pipe DOT through Graphviz to produce SVG:
+
+  bmad sprint graph | dot -Tsvg > sprint.svg
+
+The graph operates on the *resolved* edges — same source of truth that
+` + "`bmad story next`" + ` consumes. Epic-level requires_epics edges (issue
+#46) will render as dashed lines once that resolver lands; story-level
+depends_on edges render as solid lines today.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := context.Background()
+			format, err := appsprint.ParseFormat(formatFlag)
+			if err != nil {
+				return err
+			}
+
+			db, err := openV6DB(ctx)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			builder := &appsprint.GraphBuilder{
+				Stories:      sqlite.NewStoriesStore(db),
+				Dependencies: sqlite.NewStoryDependenciesStore(db),
+			}
+			g, err := builder.Build(ctx, appsprint.GraphBuilderOptions{
+				Scope:            scope,
+				IncludeCompleted: includeCompleted,
+			})
+			if err != nil {
+				return err
+			}
+
+			// --json (top-level) wins over --format: it wraps the JSON-graph
+			// envelope inside the standard v1 envelope so AI agents get a
+			// single uniform shape across every bmad command. Operators who
+			// want the raw graph envelope use `--format json` without
+			// `--json`.
+			if jsonOutput {
+				result := appsprint.JSONGraphEnvelope{
+					SchemaVersion: appsprint.JSONGraphSchemaVersion,
+					Scope:         g.Scope,
+					NodeCount:     len(g.Nodes),
+					EdgeCount:     len(g.Edges),
+					Nodes:         normaliseNodes(g.Nodes),
+					Edges:         normaliseEdges(g.Edges),
+				}
+				return emitJSONStdout(commandPathSansRoot(c), map[string]any{
+					"format":            string(format),
+					"scope":             scope,
+					"with_status":       withStatus,
+					"include_completed": includeCompleted,
+				}, result, nil)
+			}
+
+			renderer, err := appsprint.NewRenderer(format, withStatus)
+			if err != nil {
+				return err
+			}
+			if err := renderer.Render(os.Stdout, g); err != nil {
+				return fmt.Errorf("sprint graph render: %w", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&formatFlag, "format", "dot",
+		"output format: dot | mermaid | json")
+	cmd.Flags().StringVar(&scope, "scope", "",
+		"restrict to one epic id (e.g. --scope 7); transitive upstream nodes included")
+	cmd.Flags().BoolVar(&withStatus, "with-status", true,
+		"colour nodes by their status (set false for monochrome output)")
+	cmd.Flags().BoolVar(&includeCompleted, "include-completed", true,
+		"include complete stories (set false to focus on remaining work)")
+	return cmd
+}
+
+// normaliseNodes / normaliseEdges guarantee `[]` (never `null`) inside the
+// top-level --json envelope. Mirrors the JSONRenderer's behaviour — the
+// renderer normalises before encode; the cobra path bypasses the renderer
+// when --json is set, so we normalise here too.
+func normaliseNodes(in []appsprint.Node) []appsprint.Node {
+	if in == nil {
+		return []appsprint.Node{}
+	}
+	return in
+}
+
+func normaliseEdges(in []appsprint.Edge) []appsprint.Edge {
+	if in == nil {
+		return []appsprint.Edge{}
+	}
+	return in
+}

--- a/cmd/sprint_graph_test.go
+++ b/cmd/sprint_graph_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	appsprint "github.com/sosalejandro/bmad-story-runner-cli/application/sprint"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+// seedGraphFixtureForCmd writes a small 3-story DAG to a DB, returns its path.
+// Smaller than the app-layer fixture — we only need enough nodes to verify
+// the cobra wire-up reaches the renderer.
+func seedGraphFixtureForCmd(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bmad-state.db")
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	stories := sqlite.NewStoriesStore(db)
+	deps := sqlite.NewStoryDependenciesStore(db)
+	now := time.Now()
+	for _, s := range []state.Story{
+		{ID: "1.1", Title: "alpha", Status: state.StatusComplete, Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode, CreatedAt: now, UpdatedAt: now},
+		{ID: "1.2", Title: "beta", Status: state.StatusInProgress, Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode, CreatedAt: now, UpdatedAt: now},
+		{ID: "2.1", Title: "gamma", Status: state.StatusPending, Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := stories.Insert(ctx, s); err != nil {
+			t.Fatalf("seed %s: %v", s.ID, err)
+		}
+	}
+	if err := deps.Add(ctx, "1.2", "1.1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Add(ctx, "2.1", "1.2"); err != nil {
+		t.Fatal(err)
+	}
+	return dbPath
+}
+
+// TestSprintGraphCmd_DOT — default invocation emits DOT.
+func TestSprintGraphCmd_DOT(t *testing.T) {
+	dbPath := seedGraphFixtureForCmd(t)
+	t.Setenv("BMAD_STATE", dbPath)
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "graph"})
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"digraph sprint {",
+		`"1.1" [label=`,
+		`"1.2" -> "1.1";`,
+		`"2.1" -> "1.2";`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DOT output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestSprintGraphCmd_Mermaid — --format mermaid emits Mermaid syntax.
+func TestSprintGraphCmd_Mermaid(t *testing.T) {
+	dbPath := seedGraphFixtureForCmd(t)
+	t.Setenv("BMAD_STATE", dbPath)
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "graph", "--format", "mermaid"})
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	for _, want := range []string{"graph TD", "s1_1[", "s1_2 --> s1_1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Mermaid output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestSprintGraphCmd_JSONFormat — --format json emits the JSONGraphEnvelope
+// directly (raw envelope, no outer v1-wrapper).
+func TestSprintGraphCmd_JSONFormat(t *testing.T) {
+	dbPath := seedGraphFixtureForCmd(t)
+	t.Setenv("BMAD_STATE", dbPath)
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "graph", "--format", "json"})
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	var env appsprint.JSONGraphEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("envelope decode: %v\n%s", err, out)
+	}
+	if env.SchemaVersion != appsprint.JSONGraphSchemaVersion {
+		t.Errorf("schema_version = %q", env.SchemaVersion)
+	}
+	if env.NodeCount != 3 || env.EdgeCount != 2 {
+		t.Errorf("counts = (n=%d, e=%d), want (3, 2)", env.NodeCount, env.EdgeCount)
+	}
+}
+
+// TestSprintGraphCmd_Scope_TransitiveUpstream — --scope 2 must surface 1.2
+// and 1.1 (the transitive upstream of 2.1).
+func TestSprintGraphCmd_Scope_TransitiveUpstream(t *testing.T) {
+	dbPath := seedGraphFixtureForCmd(t)
+	t.Setenv("BMAD_STATE", dbPath)
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SetArgs([]string{"sprint", "graph", "--scope", "2", "--format", "json"})
+	out := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	var env appsprint.JSONGraphEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	// Expect 2.1 (scope match) + 1.2 + 1.1 (transitive upstream) = 3 nodes.
+	if env.NodeCount != 3 {
+		t.Errorf("scope=2 node_count = %d, want 3 (transitive upstream)", env.NodeCount)
+	}
+}
+
+// TestSprintGraphCmd_InvalidFormat — bad --format value returns an error
+// (cobra still exits zero but the RunE error is surfaced; we assert by
+// running through root.Execute and checking the returned error).
+func TestSprintGraphCmd_InvalidFormat(t *testing.T) {
+	dbPath := seedGraphFixtureForCmd(t)
+	t.Setenv("BMAD_STATE", dbPath)
+	disableStreamTap = true
+	t.Cleanup(func() { disableStreamTap = false })
+
+	root := NewRootCmd(zap.NewNop())
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.SetArgs([]string{"sprint", "graph", "--format", "svg"})
+	// Discard stdout/stderr noise.
+	_ = captureStdout(t, func() {
+		err := root.Execute()
+		if err == nil {
+			t.Fatal("expected error for --format svg, got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown --format") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #47 — operators can now *see* the sprint DAG instead of inferring it from `story next` output.

- `bmad sprint graph` reads the resolved-edges port (`story_dependencies` + `stories`) and renders the DAG in DOT (default), Mermaid, or JSON envelope v1.
- New flags: `--format dot|mermaid|json`, `--scope N`, `--with-status`, `--include-completed`.
- `--scope N` includes the requested epic **plus every transitive upstream node** (AC4) — so an operator running `--scope 7` still sees the 4.12 dependency that gates 7.1.
- Status → colour (green=complete, yellow=in-flight, red=blocked, grey=pending) shared between DOT and Mermaid renderers via a single truth source.

## Architecture

Builder + Graph + Renderer split (SOLID):
- `application/sprint/graph.go` — pure data + pure rendering, no cobra dependencies.
- `cmd/sprint_graph.go` — thin cobra shim (flag parsing + DB open + format dispatch).
- `EdgeKind` enum (`depends_on` solid, `epic_synth` dashed) means issue #46's resolved-edges schema bump can land orthogonally; the renderer will start drawing dashed lines without code changes once #46 tags rows.

## Acceptance criteria
1. ✅ <500ms on 190-story DB — benchmark shows ~6ms.
2. ✅ Mermaid output paste-renders inside a GitHub MD code fence.
3. ✅ JSON envelope v1 contract documented + tested (`schema_version`, `node_count`, `edge_count`, `nodes[]`, `edges[]`).
4. ✅ `--scope 7` filters to Epic 7 + transitive upstream.
5. ✅ Status colours match `stories.status` truth source.
6. ✅ 4-epic synthetic DAG fixture + snapshot tests for all three formats.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All 12 `application/sprint` graph tests pass
- [x] All 5 `cmd` cobra-layer graph tests pass
- [x] Benchmark `BenchmarkGraphBuild_190Stories` confirms <500ms budget (6ms actual)
- [x] Smoke test: `bmad sprint graph --help` renders correctly
- [ ] Reviewer: paste the mermaid output of a real sprint into a GitHub issue and confirm inline render

## Orthogonal to #46

Issue #46 (epic-level `requires_epics` synthesised edges) is expected to land in parallel. This PR consumes the resolved-edges port via `state.StoryDependencies.Of`, so when #46 starts tagging rows as `EdgeKindEpicSynth`, the renderer picks them up automatically — no merge collisions, no rework.