### PR TITLE
ci(release): stamp commit + build date into go-install binaries (closes #56)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,8 +8,153 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.release.outputs.pr }}
+      version: ${{ steps.release.outputs.version }}
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           target-branch: main
           release-type: go
+
+  stamp-release-pr:
+    # Bake the literal Version / CommitSHA / BuildDate into cmd/version.go on
+    # the release-please PR branch BEFORE it merges. Once merged + tagged,
+    # `go install module@vX.Y.Z` pulls source with the constants set, so the
+    # ldflags-priority path in resolveVersionFields() returns real values
+    # without needing a downloaded binary. See issue #56.
+    #
+    # SECURITY: All inputs flow from the trusted release-please action's
+    # outputs (the only "untrusted" thing in the PR JSON is the headBranchName
+    # which release-please itself authored). Even so, every interpolated
+    # value is passed via env: and dereferenced as "$VAR" inside run: blocks,
+    # not splatted into the script body — see the GitHub Actions injection
+    # hardening guide.
+    needs: release-please
+    if: needs.release-please.outputs.pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: derive release metadata
+        id: meta
+        env:
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
+          FALLBACK_VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="$(printf '%s' "$PR_JSON" | jq -r '.headBranchName // empty')"
+          VERSION="$(printf '%s' "$PR_JSON" | jq -r '.version // empty')"
+          if [ -z "$BRANCH" ]; then
+            echo "release-please pr output missing headBranchName" >&2
+            exit 1
+          fi
+          if [ -z "$VERSION" ]; then
+            VERSION="$FALLBACK_VERSION"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "release-please did not expose a version; aborting stamp" >&2
+            exit 1
+          fi
+          # Defensive: branch name + version both come from release-please,
+          # but we still validate shape before letting them touch the shell
+          # (belt-and-braces against a future release-please bug).
+          case "$BRANCH" in
+            release-please--*) ;;
+            *)
+              echo "unexpected release-please branch name: $BRANCH" >&2
+              exit 1
+              ;;
+          esac
+          case "$VERSION" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "unexpected version shape: $VERSION" >&2
+              exit 1
+              ;;
+          esac
+          echo "branch=$BRANCH" >>"$GITHUB_OUTPUT"
+          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
+
+      - name: checkout release-please branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.branch }}
+          # Need the full history so HEAD~0 here equals the release-please
+          # auto-commit and HEAD~1 is the last real change being shipped.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: stamp cmd/version.go
+        id: stamp
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # CommitSHA = HEAD~1 of the release branch — i.e. the commit that
+          # release-please built its CHANGELOG/manifest commit on top of.
+          # That's the last "real" change going out in this release. Once
+          # the PR merges + the tag cuts, this SHA is what users will see
+          # as the canonical "what's in this release" pointer.
+          COMMIT="$(git rev-parse --short HEAD~1)"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          echo "stamping: version=v${VERSION} commit=${COMMIT} date=${DATE}"
+
+          # Idempotent in-place edit driven by Python so we don't have to
+          # ship-quote backslashes through sed. Only flips the literal
+          # placeholders ("dev" / "unknown") so a re-run after release-please
+          # force-pushes the PR branch (e.g. additional commits land on main)
+          # still stamps correctly without double-rewriting.
+          python3 - "$VERSION" "$COMMIT" "$DATE" <<'PY'
+          import pathlib, re, sys
+
+          version, commit, date = sys.argv[1], sys.argv[2], sys.argv[3]
+          path = pathlib.Path("cmd/version.go")
+          src = path.read_text()
+
+          replacements = [
+              (r'(\bVersion\s*=\s*)"dev"',       f'\\1"v{version}"'),
+              (r'(\bCommitSHA\s*=\s*)"unknown"', f'\\1"{commit}"'),
+              (r'(\bBuildDate\s*=\s*)"unknown"', f'\\1"{date}"'),
+          ]
+
+          new = src
+          for pat, repl in replacements:
+              new = re.sub(pat, repl, new, count=1)
+
+          if new != src:
+              path.write_text(new)
+          else:
+              print("no placeholders matched — already stamped or shape changed", file=sys.stderr)
+          PY
+
+          echo "commit=${COMMIT}" >>"$GITHUB_OUTPUT"
+          echo "date=${DATE}" >>"$GITHUB_OUTPUT"
+
+      - name: commit + push stamps
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          COMMIT: ${{ steps.stamp.outputs.commit }}
+          DATE: ${{ steps.stamp.outputs.date }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          if git diff --quiet cmd/version.go; then
+            echo "no changes to cmd/version.go — already stamped, skipping"
+            exit 0
+          fi
+
+          git add cmd/version.go
+          git commit -m "chore(release): stamp build metadata for v${VERSION}
+
+          version=v${VERSION}
+          commit=${COMMIT}
+          date=${DATE}"
+          git push origin "HEAD:${BRANCH}"

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -125,6 +125,36 @@ func TestShortSHA(t *testing.T) {
 	}
 }
 
+func TestVersionString_StampedReleaseValuesAreVerbatim(t *testing.T) {
+	// Models the post-release-please-stamp state: the workflow has rewritten
+	// the package-level defaults inside cmd/version.go to literal release
+	// values, so a `go install module@vX.Y.Z` build sees Version/CommitSHA/
+	// BuildDate already populated at the package level (no -X needed).
+	//
+	// Contract: when all three fields are non-default + non-empty, the
+	// BuildInfo fallback MUST NOT fire. This is the load-bearing test for
+	// issue #56 — if it regresses, `bmad --version` from a `go install`
+	// silently falls back to BuildInfo and the stamp work is wasted.
+	withVersionVars(t, "v0.4.0", "a1b2c3d", "2026-05-22T13:00:36Z")
+
+	version, commit, date := resolveVersionFields()
+
+	if version != "v0.4.0" {
+		t.Errorf("stamped Version = %q, want %q (BuildInfo must not override)", version, "v0.4.0")
+	}
+	if commit != "a1b2c3d" {
+		t.Errorf("stamped CommitSHA = %q, want %q (BuildInfo must not override)", commit, "a1b2c3d")
+	}
+	if date != "2026-05-22T13:00:36Z" {
+		t.Errorf("stamped BuildDate = %q, want %q (BuildInfo must not override)", date, "2026-05-22T13:00:36Z")
+	}
+
+	want := "v0.4.0 (commit a1b2c3d, built 2026-05-22T13:00:36Z)"
+	if got := VersionString(); got != want {
+		t.Errorf("VersionString() = %q, want %q", got, want)
+	}
+}
+
 func TestVersionString_PartialLdflagsStillUsesBuildInfoForRest(t *testing.T) {
 	// A partial stamp — only Version overridden — should still pull
 	// commit + date from BuildInfo when they're at defaults. This is


### PR DESCRIPTION
## Summary

Fixes `bmad --version` showing `commit unknown, built unknown` after `go install github.com/sosalejandro/bmad-story-runner-cli/cmd/bmad@vX.Y.Z`.

Implements **Option A** from issue #56 — a new `stamp-release-pr` job in the release-please workflow rewrites the package-level `Version` / `CommitSHA` / `BuildDate` constants in `cmd/version.go` to literal release values and pushes the change onto the release-please PR branch *before* it merges. Once merged + tagged, source served at the tag has values baked in, so the ldflags-priority path in `resolveVersionFields()` returns real data without any `-X` flags or downloaded binary.

## Technical changes

- `.github/workflows/release-please.yml`
  - Promote the existing release-please step to expose `pr`, `version`, `release_created` outputs
  - New `stamp-release-pr` job (gated on `needs.release-please.outputs.pr != ''`):
    - Parses release-please's PR JSON via `jq` → branch name + version
    - Shape-validates both inputs (`release-please--*`, `N.N.N`) before any shell use
    - Checks out the release-please branch with full history
    - Computes `COMMIT = git rev-parse --short HEAD~1` (release-please's auto-commit is HEAD; HEAD~1 is the last real change going out)
    - Computes `DATE = date -u +%Y-%m-%dT%H:%M:%SZ`
    - Python regex rewrites only the literal `"dev"` / `"unknown"` placeholders → idempotent on re-run
    - Commits + pushes back to the release branch only when there's a real diff
  - All untrusted-ish inputs (`PR_JSON`, version, branch) flow via `env:` → `"$VAR"` per the GitHub Actions injection-hardening guide
- `cmd/version_test.go`
  - Adds `TestVersionString_StampedReleaseValuesAreVerbatim` as the load-bearing regression test: when all three vars are non-default, BuildInfo MUST NOT clobber them

## Local end-to-end verification

```bash
# applied the same regex the workflow uses
$ python3 stamp.py 0.4.0 a1b2c3d 2026-05-22T13:00:36Z
$ go build -o /tmp/bmad ./cmd/bmad && /tmp/bmad --version
bmad version v0.4.0 (commit a1b2c3d, built 2026-05-22T13:00:36Z)
```

Matches the target output from the issue, no `unknown` anywhere.

## Acceptance criteria

- [x] `go install ...@vX.Y.Z` → real commit + real build date (proven locally; CI cycle proves end-to-end on the next merge)
- [x] Existing ldflags pathway (`-X cmd.Version=...`) remains supported — `TestVersionString_LdflagsTakePrecedence` still green
- [x] `dev` build (`go build` from local clone) still falls back via `debug.ReadBuildInfo()` — `TestVersionString_FallsBackToBuildInfo` still green
- [ ] Verified end-to-end by cutting v0.X.Y release — happens on first post-merge release-please cycle
- [ ] Option B (GoReleaser prebuilt binaries) — not implemented; Option A alone satisfies AC #1 + #4, and the issue marks Option B as complementary

## Test plan

- [x] `go test ./cmd/` — all version tests pass
- [x] `go test ./...` — full suite green
- [x] Local stamp dry-run produces correct `--version` output
- [ ] First release-please PR after merge stamps the file (observe in CI)
- [ ] Post-tag `go install @vX.Y.Z` shows real commit + date

Closes #56