### PR TITLE
fix(sprint): tolerate file-level top frontmatter + trailing hrules (closes #58)

### DIFF
--- a/application/sprint/parser.go
+++ b/application/sprint/parser.go
@@ -300,17 +300,31 @@ func ParseEpicsFileFull(path string) (ParsedEpicsFile, error) {
 		// a fresh `---` after `## Epic` (and BEFORE any `### Story`)
 		// belongs to the epic. A `---` after `### Story` belongs to the
 		// story.
+		//
+		// Each entity (epic / story) accepts AT MOST ONE frontmatter
+		// block — the one immediately following its header. Subsequent
+		// `---` lines inside the body are treated as markdown horizontal
+		// rules and ignored. This matches the documented grammar and
+		// prevents the parser from greedily slurping body content (e.g.
+		// trailing summary tables) into yaml.Unmarshal (issue #58).
+		// Same rule covers the file-level top frontmatter that some
+		// workflows emit above the first `## Epic N` header — it has no
+		// owner, so it falls through to the free-floating branch.
 		if strings.TrimSpace(line) == "---" {
 			if !inYAML {
-				// Entering YAML. Pick the owner based on document state.
-				if currentStory != nil {
+				// Entering YAML. Pick the owner based on document state,
+				// but only if that owner hasn't already consumed its one
+				// frontmatter block. A re-opener is a horizontal rule.
+				switch {
+				case currentStory != nil && !currentStory.HasFrontmatter:
 					yamlOwner = "story"
-				} else if currentEpic != nil {
+				case currentStory == nil && currentEpic != nil && !currentEpic.HasFrontmatter:
 					yamlOwner = "epic"
-				} else {
-					// Free-floating `---` before any header — treat as
-					// no-op (covers the markdown title-front-matter pattern
-					// some authors keep at the very top of the file).
+				default:
+					// Either no entity is open (free-floating `---`,
+					// covers the workflow-metadata frontmatter at the top
+					// of the file) or the open entity already has its
+					// frontmatter — treat as a horizontal rule, no-op.
 					continue
 				}
 				inYAML = true

--- a/application/sprint/parser_test.go
+++ b/application/sprint/parser_test.go
@@ -131,6 +131,101 @@ depends_on: []
 	}
 }
 
+// TestParseEpicsFile_TolerateWorkflowFrontmatterAndTrailingHRules is a
+// regression test for issue #58 — v0.3.0's ParseEpicsFileFull rejected a real
+// 190-story epics.md file with:
+//
+//	yaml parse: yaml: line 4: did not find expected alphabetic or numeric character
+//
+// Two patterns must be tolerated:
+//
+//  1. **File-level top frontmatter** above the first `## Epic N` header. Some
+//     workflow tools (e.g. bmad-bmm) prepend a yaml block with metadata like
+//     `stepsCompleted`, `completedAt`, `inputDocuments`. Those keys don't
+//     correspond to EpicFrontmatter / StoryFrontmatter fields and may contain
+//     types (quoted dates, multi-line strings, nested lists) the typed structs
+//     would choke on. The parser must skip the block, not try to unmarshal it.
+//
+//  2. **Horizontal-rule `---` lines between sections inside the document body**
+//     (after a story's frontmatter has closed, e.g. before a trailing summary
+//     section). Each entity (epic / story) accepts AT MOST ONE frontmatter
+//     block — the one immediately following its header. Subsequent `---` lines
+//     are markdown horizontal rules and must not re-open another YAML buffer
+//     that greedily slurps body text into yaml.Unmarshal.
+//
+// Both shapes co-exist in the real nutrition-v2-go EDA cutover epics.md.
+func TestParseEpicsFile_TolerateWorkflowFrontmatterAndTrailingHRules(t *testing.T) {
+	t.Parallel()
+	path := writeEpics(t, `---
+stepsCompleted: [1, 2, 3, 4]
+status: 'complete'
+completedAt: '2026-05-16'
+inputDocuments:
+  - foo/architecture.md
+  - foo/decision-tree.md
+prdSubstitution: |
+  No formal PRD. This brownfield refactor uses the decision tree + audit as
+  PRD-equivalent inputs.
+project_name: 'demo (cutover)'
+---
+
+# demo — Epic Breakdown
+
+## Overview
+
+Some prose between the top frontmatter and the first epic header.
+
+## Epic 1: First Slice
+
+### Story 1.1: Hello World
+
+---
+story_id: "1.1"
+depends_on: []
+complexity: low
+---
+
+As a developer agent, I want a hello story, So that the parser is exercised.
+
+- **Given** the file
+- **When** the parser runs
+- **Then** the story is emitted
+
+---
+
+## Final Validation Summary
+
+**Status:** Complete.
+
+| Category    | Result            |
+| ----------- | ----------------- |
+| FR Coverage | All mapped        |
+| Story Count | 1 story / 1 epic  |
+
+**Total story count:** 1 story across 1 epic.
+`)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("ParseEpicsFileFull rejected workflow-frontmatter + trailing HR: %v", err)
+	}
+	if len(parsed.Epics) != 1 {
+		t.Errorf("epics = %d, want 1", len(parsed.Epics))
+	}
+	if len(parsed.Stories) != 1 {
+		t.Fatalf("stories = %d, want 1", len(parsed.Stories))
+	}
+	if parsed.Stories[0].Frontmatter.StoryID != "1.1" {
+		t.Errorf("StoryID = %q, want 1.1", parsed.Stories[0].Frontmatter.StoryID)
+	}
+	if !parsed.Stories[0].HasFrontmatter {
+		t.Errorf("HasFrontmatter = false; want true (story 1.1 has a yaml block)")
+	}
+	if parsed.Stories[0].Frontmatter.Complexity != "low" {
+		t.Errorf("Complexity = %q, want low (frontmatter must still be parsed correctly)",
+			parsed.Stories[0].Frontmatter.Complexity)
+	}
+}
+
 func TestEpicIDFromStory(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ in, want string }{


### PR DESCRIPTION
## Summary

- Fixes v0.3.0 regression: `ParseEpicsFileFull` rejected real epics.md files with `yaml parse: line 4: did not find expected alphabetic or numeric character` (issue #58).
- Each entity (epic / story) now accepts AT MOST ONE frontmatter block — the one immediately after its header. Subsequent `---` lines are treated as markdown horizontal rules.
- Adds regression test `TestParseEpicsFile_TolerateWorkflowFrontmatterAndTrailingHRules` that fails pre-fix with the exact error from issue #58 and passes post-fix.

## Root cause

The issue's title hypothesis pointed at the top file-level frontmatter, but that block was already handled (no current epic/story → free-floating no-op). The real failure was deeper in the file:

After a story's frontmatter closed, any later `---` (a markdown horizontal rule between sections — e.g. before a trailing "Final Validation Summary" section in nutrition-v2-go's 190-story epics.md) re-opened a YAML buffer scoped to the still-open story. The trailing markdown body — including a pipe-separated table — was then fed to `yaml.Unmarshal`, and yaml.v3 reported the table separator line as "line 4" of the runaway buffer (not the file).

The fix tracks `HasFrontmatter` and refuses to open a second YAML block on an entity that's already consumed its one allowed block. The same condition cleanly subsumes the previous "free-floating `---`" case (no owner → no-op).

## Verification

End-to-end against the real nutrition-v2-go EDA cutover epics.md (the file from the issue):

```
$ bmad sprint plan --epics docs/features/eda-cutover/epics.md --state ./bmad-state.db
{"stories_inserted":190,"stories_updated":0,"dependencies_added":192,"affects_added":323,"batches_created":67,...}
```

190 stories across 22 epics ingest cleanly (matches the issue's expected count).

## Test plan

- [x] New regression test `TestParseEpicsFile_TolerateWorkflowFrontmatterAndTrailingHRules` FAILS on `main` (verified via `git stash`) with the exact issue #58 error message
- [x] Same test PASSES post-fix
- [x] All other `application/sprint` parser tests still pass (`TestParseEpicsFile_StoryWithFullFrontmatter`, `_MultipleStories`, `_StoryWithoutFrontmatterStillEmitted`, `_HasFrontmatterFlagSetOnYAML`, `TestParseEpicsFileFull_CapturesEpicRequiresFrontmatter`)
- [x] End-to-end `bmad sprint plan` succeeds against the 3245-line real file → 190 stories / 22 epics / 67 batches
- [x] Conventional commit `fix:` so release-please cuts v0.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)