### PR TITLE
fix(ci): read release version from manifest, not release-please pr output (closes #64)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,29 +39,29 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: derive release metadata
+      - name: derive release branch
         id: meta
         env:
           PR_JSON: ${{ needs.release-please.outputs.pr }}
-          FALLBACK_VERSION: ${{ needs.release-please.outputs.version }}
         run: |
           set -euo pipefail
+          # The release-please-action v4 `pr` output is a JSON blob describing
+          # the just-opened/updated release PR. It exposes `headBranchName`
+          # but NOT a top-level `.version` field (see issue #64) — the version
+          # is only available in the PR title/body or, authoritatively, in
+          # `.release-please-manifest.json` on the release branch itself.
+          # The action's `outputs.version` is likewise empty at PR-open time
+          # (only populated AFTER the release is cut). So this step extracts
+          # just the branch; the version is read post-checkout from the
+          # manifest, which is the single source of truth.
           BRANCH="$(printf '%s' "$PR_JSON" | jq -r '.headBranchName // empty')"
-          VERSION="$(printf '%s' "$PR_JSON" | jq -r '.version // empty')"
           if [ -z "$BRANCH" ]; then
             echo "release-please pr output missing headBranchName" >&2
             exit 1
           fi
-          if [ -z "$VERSION" ]; then
-            VERSION="$FALLBACK_VERSION"
-          fi
-          if [ -z "$VERSION" ]; then
-            echo "release-please did not expose a version; aborting stamp" >&2
-            exit 1
-          fi
-          # Defensive: branch name + version both come from release-please,
-          # but we still validate shape before letting them touch the shell
-          # (belt-and-braces against a future release-please bug).
+          # Defensive: branch name comes from release-please, but we still
+          # validate shape before letting it touch the shell (belt-and-braces
+          # against a future release-please bug or a malformed PR payload).
           case "$BRANCH" in
             release-please--*) ;;
             *)
@@ -69,15 +69,7 @@ jobs:
               exit 1
               ;;
           esac
-          case "$VERSION" in
-            [0-9]*.[0-9]*.[0-9]*) ;;
-            *)
-              echo "unexpected version shape: $VERSION" >&2
-              exit 1
-              ;;
-          esac
           echo "branch=$BRANCH" >>"$GITHUB_OUTPUT"
-          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
 
       - name: checkout release-please branch
         uses: actions/checkout@v4
@@ -88,10 +80,37 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: read version from release-please manifest
+        id: version
+        run: |
+          set -euo pipefail
+          # `.release-please-manifest.json` is the single source of truth for
+          # the next-release version number — release-please refreshes it on
+          # every PR open/force-push, so it always matches the PR title/body
+          # and the upcoming tag. Reading it here (post-checkout) sidesteps
+          # the broken `pr.version` / `outputs.version` paths flagged in #64.
+          if [ ! -f .release-please-manifest.json ]; then
+            echo "release-please manifest missing on branch" >&2
+            exit 1
+          fi
+          VERSION="$(jq -r '."."' .release-please-manifest.json)"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "release-please manifest has no '.' entry" >&2
+            exit 1
+          fi
+          case "$VERSION" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "manifest version has unexpected shape: $VERSION" >&2
+              exit 1
+              ;;
+          esac
+          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
+
       - name: stamp cmd/version.go
         id: stamp
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           # CommitSHA = HEAD~1 of the release branch — i.e. the commit that
@@ -104,11 +123,15 @@ jobs:
 
           echo "stamping: version=v${VERSION} commit=${COMMIT} date=${DATE}"
 
-          # Idempotent in-place edit driven by Python so we don't have to
-          # ship-quote backslashes through sed. Only flips the literal
-          # placeholders ("dev" / "unknown") so a re-run after release-please
-          # force-pushes the PR branch (e.g. additional commits land on main)
-          # still stamps correctly without double-rewriting.
+          # In-place edit driven by Python so we don't have to ship-quote
+          # backslashes through sed. The regexes match ANY current literal
+          # (the original "dev"/"unknown" placeholders on a first-ever stamp,
+          # or the prior release's stamped values on subsequent releases) and
+          # rewrite to the values for this release. This is critical: each
+          # release-please PR branches off `main`, so on the 2nd+ release
+          # cmd/version.go already contains the PREVIOUS release's stamps,
+          # not the original placeholders. A placeholder-only regex (the
+          # earlier impl) silently no-op'd in that case.
           python3 - "$VERSION" "$COMMIT" "$DATE" <<'PY'
           import pathlib, re, sys
 
@@ -116,20 +139,32 @@ jobs:
           path = pathlib.Path("cmd/version.go")
           src = path.read_text()
 
+          # Group 1 = the `<Name> = ` var-decl prefix.
+          # Group 2 = the CURRENT quoted literal (any value).
+          # We rewrite group 2 to the new literal, preserving formatting.
           replacements = [
-              (r'(\bVersion\s*=\s*)"dev"',       f'\\1"v{version}"'),
-              (r'(\bCommitSHA\s*=\s*)"unknown"', f'\\1"{commit}"'),
-              (r'(\bBuildDate\s*=\s*)"unknown"', f'\\1"{date}"'),
+              (r'(\bVersion\s*=\s*)"([^"]*)"',   f'\\1"v{version}"'),
+              (r'(\bCommitSHA\s*=\s*)"([^"]*)"', f'\\1"{commit}"'),
+              (r'(\bBuildDate\s*=\s*)"([^"]*)"', f'\\1"{date}"'),
           ]
 
           new = src
           for pat, repl in replacements:
-              new = re.sub(pat, repl, new, count=1)
+              new, n = re.subn(pat, repl, new, count=1)
+              if n != 1:
+                  print(f"pattern did not match exactly once: {pat}", file=sys.stderr)
+                  sys.exit(1)
 
-          if new != src:
-              path.write_text(new)
+          if new == src:
+              # All three patterns matched but produced identical text —
+              # i.e. the file already has the exact values for this release
+              # (possible if the workflow re-runs after a release-please
+              # force-push that didn't bump the version, e.g. a changelog
+              # touch-up). Safe no-op; `git diff --quiet` in the commit step
+              # detects this and skips the push.
+              print("file already has target stamps; nothing to write")
           else:
-              print("no placeholders matched — already stamped or shape changed", file=sys.stderr)
+              path.write_text(new)
           PY
 
           echo "commit=${COMMIT}" >>"$GITHUB_OUTPUT"
@@ -137,7 +172,7 @@ jobs:
 
       - name: commit + push stamps
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           COMMIT: ${{ steps.stamp.outputs.commit }}
           DATE: ${{ steps.stamp.outputs.date }}
           BRANCH: ${{ steps.meta.outputs.branch }}


### PR DESCRIPTION
## Summary

- **Root cause:** the `stamp-release-pr` job (added in #57) reads the next-release version from `pr-json.version` (which the release-please-action v4 `pr` output does NOT contain) and falls back to `outputs.version` (which is only populated AFTER the release is cut, not at PR-open). Result: the job has aborted at *"release-please did not expose a version; aborting stamp"* on **every release since #57 landed** (v0.3.0, v0.3.1, v0.4.0). `cmd/version.go` on `main` still contains the original `"dev"` / `"unknown"` placeholders, so installed binaries report `commit unknown, built unknown`.
- **Fix:** drop the broken jq paths. Derive only the branch name from `PR_JSON`, then read the version from `.release-please-manifest.json` on the checked-out release branch — that file is the single source of truth, refreshed by release-please on every PR open/force-push.
- **Follow-on fix:** the python rewrite only matched the `"dev"`/`"unknown"` placeholders, so on the 2nd+ release (when `cmd/version.go` already has the prior release's stamps) it silently no-op'd. New regex matches any current quoted literal; `git diff --quiet` in the commit step still skips the push when the file is already at the target values.

## Why option (b) from #64

The issue proposed three options. Option (b) — read from `.release-please-manifest.json` — was selected because the manifest is the single authoritative source release-please writes, no parsing of human-readable PR titles required, and it's already at `HEAD` of the release branch by the time we check it out.

## Security

All untrusted-ish inputs (`PR_JSON`, manifest contents) flow through `env:` and are dereferenced as `"$VAR"` inside `run:` blocks — no direct `${{ }}` shell interpolation. Branch name + version are both regex-validated before they touch the shell.

## Test plan

- [x] Build clean (`go build ./...`)
- [x] `go test ./cmd/...` passes
- [x] Python regex dry-run on actual `cmd/version.go`: first-stamp scenario (placeholders) writes correct values; re-stamp scenario (prior release's values) overwrites correctly; `defaultVersion`/`defaultCommitSHA`/`defaultBuildDate` constants are NOT touched (word-boundary correctly excludes them)
- [x] YAML lint clean
- [ ] **Live verification:** after merge, the next `fix:` commit on `main` will open a release-please PR; the stamp job should now run successfully on it. Once that PR merges and the tag cuts, `go install …@<new-tag>` should produce a binary whose `--version` shows the new tag's commit + a fresh build date.

Closes #64. Related: #56, #57, #58, atlas#49 (sister issue, same pattern).