### PR TITLE
feat(sprint): tag story_dependencies edges with edge_kind discriminator (closes #54)

### DIFF
--- a/application/sprint/graph.go
+++ b/application/sprint/graph.go
@@ -41,9 +41,26 @@ const (
 	// EdgeKindDepends is a story-level depends_on edge — solid line.
 	EdgeKindDepends EdgeKind = "depends_on"
 	// EdgeKindEpicSynth is an epic-level requires_epics edge synthesised by
-	// the epic-DAG resolver (issue #46) — dashed line.
+	// the epic-DAG resolver (issue #46) — dashed line. As of issue #54 it
+	// also covers requires_stories synthesis, because both share the
+	// "epic-level, not story-author intent" semantic that justifies the
+	// dashed treatment.
 	EdgeKindEpicSynth EdgeKind = "epic_synth"
 )
+
+// edgeKindFromState maps a persistence-layer DependencyEdgeKind onto the
+// renderer-side EdgeKind. Synth kinds (epic_synth, epic_synth_stories) both
+// fold into EdgeKindEpicSynth — the renderer doesn't need to distinguish
+// them visually (both are dashed); a future "explicit synth" enrichment
+// can split them by extending this switch without touching the renderer.
+func edgeKindFromState(k state.DependencyEdgeKind) EdgeKind {
+	switch k {
+	case state.EdgeKindEpicSynth, state.EdgeKindEpicSynthStories:
+		return EdgeKindEpicSynth
+	default:
+		return EdgeKindDepends
+	}
+}
 
 // NodeKind classifies a graph node — story vs epic-summary cluster.
 type NodeKind string
@@ -126,24 +143,23 @@ func (b *GraphBuilder) Build(ctx context.Context, opts GraphBuilderOptions) (*Gr
 	}
 
 	// Collect every edge by iterating each story's depends_on list. We
-	// intentionally call .Of per story (not a single bulk read) because the
-	// port doesn't expose a bulk variant today, and 190 stories × 1 SELECT
-	// each on a local SQLite file is ~10ms in practice — well under the
-	// 500ms acceptance budget.
+	// intentionally call EdgesOf per story (not a single bulk read) because
+	// the port doesn't expose a bulk variant today, and 190 stories × 1
+	// SELECT each on a local SQLite file is ~10ms in practice — well under
+	// the 500ms acceptance budget. EdgesOf surfaces the persisted edge_kind
+	// (issue #54) so we can route epic-synth rows to the dashed renderer
+	// without re-deriving them at read time.
 	var rawEdges []Edge
 	for _, s := range all {
-		deps, err := b.Dependencies.Of(ctx, s.ID)
+		edges, err := b.Dependencies.EdgesOf(ctx, s.ID)
 		if err != nil {
 			return nil, fmt.Errorf("graph builder: deps for %q: %w", s.ID, err)
 		}
-		for _, dep := range deps {
+		for _, e := range edges {
 			rawEdges = append(rawEdges, Edge{
 				From: s.ID,
-				To:   dep,
-				// Currently all rows are story-level; epic-synth edges (issue
-				// #46) will tag themselves once the resolved-edges schema
-				// gains an edge_kind column.
-				Kind: EdgeKindDepends,
+				To:   e.DependsOnID,
+				Kind: edgeKindFromState(e.Kind),
 			})
 		}
 	}

--- a/application/sprint/graph_test.go
+++ b/application/sprint/graph_test.go
@@ -367,6 +367,95 @@ func TestRenderDOT_SubjectClippedAt30Chars(t *testing.T) {
 	}
 }
 
+// TestRenderDOT_SynthEdgesAreDashed — issue #54 acceptance criterion #3.
+// When the persisted edge_kind marks a row as epic_synth, the DOT renderer
+// MUST emit `style=dashed` on that edge while leaving explicit edges
+// unadorned. Mirrored by TestRenderMermaid_SynthEdgesUseDashedArrow below.
+func TestRenderDOT_SynthEdgesAreDashed(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	storiesStore := sqlite.NewStoriesStore(db)
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	ctx := context.Background()
+	now := time.Now()
+	for _, id := range []string{"1.1", "1.2", "2.1"} {
+		if err := storiesStore.Insert(ctx, state.Story{
+			ID: id, Title: "s " + id, Status: state.StatusPending,
+			Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	// Mixed seed: 2.1 → 1.1 = explicit; 2.1 → 1.2 = epic_synth.
+	if err := depsStore.AddWithKind(ctx, "2.1", "1.1", state.EdgeKindExplicit); err != nil {
+		t.Fatalf("AddWithKind explicit: %v", err)
+	}
+	if err := depsStore.AddWithKind(ctx, "2.1", "1.2", state.EdgeKindEpicSynth); err != nil {
+		t.Fatalf("AddWithKind epic_synth: %v", err)
+	}
+
+	b := &sprint.GraphBuilder{Stories: storiesStore, Dependencies: depsStore}
+	g, err := b.Build(ctx, sprint.GraphBuilderOptions{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	r := &sprint.DOTRenderer{WithStatus: false}
+	var buf bytes.Buffer
+	if err := r.Render(&buf, g); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	// epic_synth edge: dashed
+	if !strings.Contains(out, `"2.1" -> "1.2" [style=dashed]`) {
+		t.Errorf("expected dashed synth edge 2.1->1.2, got:\n%s", out)
+	}
+	// explicit edge: not dashed (the bare `... -> ...;` form)
+	if !strings.Contains(out, `"2.1" -> "1.1";`) {
+		t.Errorf("expected solid explicit edge 2.1->1.1, got:\n%s", out)
+	}
+	if strings.Contains(out, `"2.1" -> "1.1" [style=dashed]`) {
+		t.Errorf("explicit edge incorrectly rendered dashed:\n%s", out)
+	}
+}
+
+// TestRenderMermaid_SynthEdgesUseDashedArrow — same contract as the DOT
+// test but for Mermaid's `-.->` form.
+func TestRenderMermaid_SynthEdgesUseDashedArrow(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	storiesStore := sqlite.NewStoriesStore(db)
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+	ctx := context.Background()
+	now := time.Now()
+	for _, id := range []string{"1.1", "1.2", "2.1"} {
+		if err := storiesStore.Insert(ctx, state.Story{
+			ID: id, Title: "s " + id, Status: state.StatusPending,
+			Complexity: state.ComplexityMedium, StoryType: state.StoryTypeCode,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	_ = depsStore.AddWithKind(ctx, "2.1", "1.1", state.EdgeKindExplicit)
+	_ = depsStore.AddWithKind(ctx, "2.1", "1.2", state.EdgeKindEpicSynthStories)
+
+	b := &sprint.GraphBuilder{Stories: storiesStore, Dependencies: depsStore}
+	g, _ := b.Build(ctx, sprint.GraphBuilderOptions{IncludeCompleted: true})
+	r := &sprint.MermaidRenderer{WithStatus: false}
+	var buf bytes.Buffer
+	if err := r.Render(&buf, g); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `s2_1 -.-> s1_2`) {
+		t.Errorf("expected dashed mermaid arrow s2_1 -.-> s1_2, got:\n%s", out)
+	}
+	if !strings.Contains(out, `s2_1 --> s1_1`) {
+		t.Errorf("expected solid mermaid arrow s2_1 --> s1_1, got:\n%s", out)
+	}
+}
+
 // ----------------------------------------------------------------------------
 // helpers
 // ----------------------------------------------------------------------------

--- a/application/sprint/planner.go
+++ b/application/sprint/planner.go
@@ -157,27 +157,50 @@ func (p *Planner) PlanWithEpics(ctx context.Context, epics []ParsedEpic, parsed 
 	// sees the unified depends_on list. We don't mutate the caller's
 	// slice — keep the parser-side ParsedStory shape pristine for any
 	// other consumer of the same `parsed` value (e.g. JSON marshalling).
+	//
+	// We ALSO keep a per-story map of (dep id → synth kind) for the rows
+	// the synthesis produced — the persistence loop below consults it so
+	// each story_dependencies row gets the right edge_kind tag (issue #54).
 	working := make([]ParsedStory, len(parsed))
 	copy(working, parsed)
+	synthKindByStoryDep := make(map[string]map[string]state.DependencyEdgeKind, len(working))
 	for i := range working {
 		extra := synth.SynthesizedDeps[working[i].Frontmatter.StoryID]
+		extraKinds := synth.SynthesizedKinds[working[i].Frontmatter.StoryID]
 		if len(extra) == 0 {
 			continue
 		}
-		// Combine, de-dup against own deps. `additional` keeps only the
-		// NEW edges so we can count them honestly in the IngestResult.
-		seen := make(map[string]struct{}, len(working[i].Frontmatter.DependsOn))
+		// Track which of the synth targets are NEW (not already in the
+		// author's depends_on) so we can count them honestly in
+		// SynthesizedDependenciesAdded. But for edge_kind attribution we
+		// ALWAYS prefer the synthesised kind — when a story author wrote
+		// `depends_on: [X]` for a target that the resolver would have
+		// synthesised anyway, the synth kind carries strictly more
+		// semantic info (it records that an epic-level declaration
+		// validates this edge), which is what `bmad sprint validate-deps`
+		// uses to suppress the placeholder-smell finding. Treating the
+		// edge as synth in this case matches the issue #54 contract:
+		// "suppress smell-warning for any edge with edge_kind != explicit".
+		authorDeps := make(map[string]struct{}, len(working[i].Frontmatter.DependsOn))
 		for _, d := range working[i].Frontmatter.DependsOn {
-			seen[d] = struct{}{}
+			authorDeps[d] = struct{}{}
+		}
+		kindMap := synthKindByStoryDep[working[i].Frontmatter.StoryID]
+		if kindMap == nil {
+			kindMap = make(map[string]state.DependencyEdgeKind, len(extra))
 		}
 		var additional []string
-		for _, e := range extra {
-			if _, ok := seen[e]; ok {
-				continue
+		for j, e := range extra {
+			kindMap[e] = mapSynthKind(extraKinds[j])
+			if _, alreadyAuthor := authorDeps[e]; alreadyAuthor {
+				continue // not a NEW edge — author already declared it
 			}
-			seen[e] = struct{}{}
 			additional = append(additional, e)
 		}
+		// Always record the kindMap, even when every synth target was
+		// already in the author's depends_on — the persistence loop needs
+		// it to overwrite the default 'explicit' kind for those rows.
+		synthKindByStoryDep[working[i].Frontmatter.StoryID] = kindMap
 		if len(additional) == 0 {
 			continue
 		}
@@ -235,12 +258,20 @@ func (p *Planner) PlanWithEpics(ctx context.Context, epics []ParsedEpic, parsed 
 			res.AffectsCleared++
 		}
 
+		kindMap := synthKindByStoryDep[st.ID]
 		for _, dep := range ps.Frontmatter.DependsOn {
 			if dep == "" {
 				continue
 			}
-			if err := p.Dependencies.Add(ctx, st.ID, dep); err != nil {
-				return nil, fmt.Errorf("planner dep %q→%q: %w", st.ID, dep, err)
+			// kindMap only carries synthesised entries; an absent lookup
+			// means the dep is story-level explicit (the original
+			// frontmatter.depends_on contract).
+			kind := state.EdgeKindExplicit
+			if k, ok := kindMap[dep]; ok {
+				kind = k
+			}
+			if err := p.Dependencies.AddWithKind(ctx, st.ID, dep, kind); err != nil {
+				return nil, fmt.Errorf("planner dep %q→%q (%s): %w", st.ID, dep, kind, err)
 			}
 			res.DependenciesAdded++
 		}
@@ -339,6 +370,24 @@ func (p *Planner) buildBatches(ctx context.Context, parsed []ParsedStory, maxPar
 	}
 
 	return out, nil
+}
+
+// mapSynthKind converts the application-layer SynthEdgeKind (pure-function
+// shape) into the persistence-layer state.DependencyEdgeKind. Kept narrow:
+// only the two synthesised kinds map through here — explicit edges are
+// written directly with state.EdgeKindExplicit by the caller.
+func mapSynthKind(k SynthEdgeKind) state.DependencyEdgeKind {
+	switch k {
+	case SynthFromEpicRequires:
+		return state.EdgeKindEpicSynth
+	case SynthFromStoryRequires:
+		return state.EdgeKindEpicSynthStories
+	default:
+		// Defensive: an unknown synth kind defaults to the broader
+		// epic-synth bucket so the row is still marked synthesised (and
+		// therefore styled dashed + suppressed from placeholder-smell).
+		return state.EdgeKindEpicSynth
+	}
 }
 
 // buildLayer greedily fills one batch from the ready set, honoring:

--- a/application/sprint/requires.go
+++ b/application/sprint/requires.go
@@ -22,11 +22,31 @@ type SynthesisResult struct {
 	// the total deps of that story.
 	SynthesizedDeps map[string][]string
 
+	// SynthesizedKinds parallels SynthesizedDeps and records WHICH kind
+	// of synthesis produced each edge — 'epic_synth' (from
+	// requires_epics:) vs 'epic_synth_stories' (from requires_stories:).
+	// Same index ordering as SynthesizedDeps[id], so callers can correlate
+	// dep id ↔ kind without a second map lookup. Issue #54.
+	SynthesizedKinds map[string][]SynthEdgeKind
+
 	// Warnings collects non-fatal diagnostics the planner should
 	// surface to the operator (placeholder linear-chain smell, missing
 	// referenced epics, etc.). Empty when the input was clean.
 	Warnings []string
 }
+
+// SynthEdgeKind discriminates the synthesis source. Distinct from
+// domain/state.DependencyEdgeKind so the application layer doesn't pull
+// the persistence-shaped enum into pure-function space; the planner maps
+// between the two when it persists.
+type SynthEdgeKind string
+
+const (
+	// SynthFromEpicRequires — generated from `requires_epics: [N]`.
+	SynthFromEpicRequires SynthEdgeKind = "epic_synth"
+	// SynthFromStoryRequires — generated from `requires_stories: [...]`.
+	SynthFromStoryRequires SynthEdgeKind = "epic_synth_stories"
+)
 
 // SynthesizeRequiresEpics walks every epic + its stories and computes the
 // `requires_epics:` / `requires_stories:` expansion. Pure function — no
@@ -57,7 +77,8 @@ type SynthesisResult struct {
 //     they're typos.
 func SynthesizeRequiresEpics(epics []ParsedEpic, stories []ParsedStory) SynthesisResult {
 	res := SynthesisResult{
-		SynthesizedDeps: make(map[string][]string, len(stories)),
+		SynthesizedDeps:  make(map[string][]string, len(stories)),
+		SynthesizedKinds: make(map[string][]SynthEdgeKind, len(stories)),
 	}
 
 	// Index: epic id → its parsed header (so we can look up RequiresEpics
@@ -116,20 +137,23 @@ func SynthesizeRequiresEpics(epics []ParsedEpic, stories []ParsedStory) Synthesi
 			bypass[b] = struct{}{}
 		}
 
-		// Track edges we've already added for this story, including the
-		// story's own declared deps — so synthesized output never duplicates
-		// what the author already wrote. The planner-side wipe-then-replace
-		// loop would handle dupes anyway, but de-duping here keeps the
-		// surfaced "N synthesized" count honest.
+		// Track synth edges we've already produced for this story so the
+		// output slice doesn't contain duplicates (e.g. the same target id
+		// would-be-emitted via both requires_epics and requires_stories).
+		// We intentionally do NOT pre-seed this with the author's
+		// depends_on — the planner needs the synth attribution for every
+		// epic-level edge even when the author independently wrote the
+		// same target, so the persisted edge_kind reflects the upstream
+		// declaration (issue #54). The planner's combine-step (in
+		// PlanWithEpics) is the single place that dedupes synth vs author
+		// for the "additional edges added" count.
 		seen := make(map[string]struct{}, len(s.Frontmatter.DependsOn)+4)
 		seen[s.Frontmatter.StoryID] = struct{}{} // never self-depend
-		for _, d := range s.Frontmatter.DependsOn {
-			if d != "" {
-				seen[d] = struct{}{}
-			}
-		}
 
+		// Track edges + their attribution. Parallel slices stay in lockstep
+		// so the final sort can carry both columns together.
 		var synth []string
+		var kinds []SynthEdgeKind
 
 		// (a) requires_epics expansion: last story of each referenced epic
 		for _, ref := range owner.Frontmatter.RequiresEpics {
@@ -155,6 +179,7 @@ func SynthesizeRequiresEpics(epics []ParsedEpic, stories []ParsedStory) Synthesi
 			}
 			seen[last] = struct{}{}
 			synth = append(synth, last)
+			kinds = append(kinds, SynthFromEpicRequires)
 		}
 
 		// (b) requires_stories expansion: literal cross-cutting pins
@@ -174,13 +199,27 @@ func SynthesizeRequiresEpics(epics []ParsedEpic, stories []ParsedStory) Synthesi
 			}
 			seen[pin] = struct{}{}
 			synth = append(synth, pin)
+			kinds = append(kinds, SynthFromStoryRequires)
 		}
 
 		if len(synth) > 0 {
-			// Deterministic order: natural-id ascending so test fixtures
-			// don't flap on map-iteration randomness.
-			sort.Slice(synth, func(i, j int) bool { return naturalLess(synth[i], synth[j]) })
-			res.SynthesizedDeps[s.Frontmatter.StoryID] = synth
+			// Deterministic order: natural-id ascending. We co-sort kinds
+			// using an index permutation so a row keeps its attribution
+			// even when stories_requires-pinned ids interleave with
+			// requires_epics-derived ones.
+			idx := make([]int, len(synth))
+			for i := range idx {
+				idx[i] = i
+			}
+			sort.Slice(idx, func(i, j int) bool { return naturalLess(synth[idx[i]], synth[idx[j]]) })
+			sortedDeps := make([]string, len(synth))
+			sortedKinds := make([]SynthEdgeKind, len(synth))
+			for i, src := range idx {
+				sortedDeps[i] = synth[src]
+				sortedKinds[i] = kinds[src]
+			}
+			res.SynthesizedDeps[s.Frontmatter.StoryID] = sortedDeps
+			res.SynthesizedKinds[s.Frontmatter.StoryID] = sortedKinds
 		}
 	}
 

--- a/application/sprint/requires_test.go
+++ b/application/sprint/requires_test.go
@@ -478,6 +478,44 @@ func TestPlanWithEpics_FourEpicSyntheticDAG(t *testing.T) {
 		}
 	}
 
+	// Issue #54 acceptance — edge_kind tagging. Every persisted row in
+	// this fixture is synth (the fixture has no story-level depends_on),
+	// and rows whose target appears in requires_stories: ["1.2"] for
+	// Epic 4 carry the more-specific 'epic_synth_stories' kind. Rows from
+	// requires_epics: get 'epic_synth'.
+	wantKinds := map[string]map[string]state.DependencyEdgeKind{
+		"2.1": {"1.3": state.EdgeKindEpicSynth},
+		"2.2": {"1.3": state.EdgeKindEpicSynth},
+		"3.1": {"1.3": state.EdgeKindEpicSynth},
+		"3.2": {"1.3": state.EdgeKindEpicSynth},
+		"4.1": {
+			"1.2": state.EdgeKindEpicSynthStories, // requires_stories
+			"2.2": state.EdgeKindEpicSynth,
+			"3.2": state.EdgeKindEpicSynth,
+		},
+		"4.2": {
+			"1.2": state.EdgeKindEpicSynthStories,
+			"2.2": state.EdgeKindEpicSynth,
+			"3.2": state.EdgeKindEpicSynth,
+		},
+	}
+	for sid, want := range wantKinds {
+		edges, err := depsStore.EdgesOf(ctx, sid)
+		if err != nil {
+			t.Fatalf("deps.EdgesOf %s: %v", sid, err)
+		}
+		got := make(map[string]state.DependencyEdgeKind, len(edges))
+		for _, e := range edges {
+			got[e.DependsOnID] = e.Kind
+		}
+		for dep, wantKind := range want {
+			if got[dep] != wantKind {
+				t.Errorf("edge_kind for %s→%s = %q, want %q (got map=%v)",
+					sid, dep, got[dep], wantKind, got)
+			}
+		}
+	}
+
 	// Batch plan must produce four topological layers (Epic 1, then 2+3
 	// parallel — but no batch can contain a story from Epic 4 alongside
 	// its prerequisites). Lower bound is 3 layers; max 4 because the
@@ -580,6 +618,167 @@ depends_on: ["1.1"]
 	if res.DependenciesAdded != 1 {
 		t.Errorf("DependenciesAdded = %d, want 1 (the explicit 1.2 → 1.1 edge)", res.DependenciesAdded)
 	}
+}
+
+// TestPlanWithEpics_MixedExplicitAndSynthEdgeKinds is the issue #54 headline
+// acceptance test: a fixture that mixes story-level explicit `depends_on`
+// declarations with epic-level synthesis MUST persist both, and the
+// edge_kind column MUST attribute each row to its source.
+//
+// Topology:
+//
+//	1.1, 1.2          — foundation, no deps
+//	2.1 depends_on 1.1 — story-author explicit
+//	2.2               — under Epic 2 which requires_epics: [1] (synthesised)
+//	3.1 depends_on 2.1 + Epic 3 requires_stories: ["1.2"]  → mixed kinds
+//
+// The persisted rows on 3.1 must split: 2.1 = explicit (author wrote it),
+// 1.2 = epic_synth_stories (planner synthesised from requires_stories).
+func TestPlanWithEpics_MixedExplicitAndSynthEdgeKinds(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	planner := &sprint.Planner{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+		Affects:      sqlite.NewStoryAffectsStore(db),
+		Batches:      sqlite.NewBatchesStore(db),
+	}
+
+	path := writeFixture(t, "epics.md", `## Epic 1: Foundation
+
+### Story 1.1: Bootstrap
+---
+story_id: "1.1"
+---
+
+### Story 1.2: Helper
+---
+story_id: "1.2"
+---
+
+## Epic 2: Linear
+
+---
+epic_id: 2
+requires_epics: [1]
+---
+
+### Story 2.1: First of Epic 2
+---
+story_id: "2.1"
+depends_on: ["1.1"]
+---
+
+### Story 2.2: Last of Epic 2
+---
+story_id: "2.2"
+---
+
+## Epic 3: Mixed Kinds
+
+---
+epic_id: 3
+requires_stories: ["1.2"]
+---
+
+### Story 3.1: Mixed
+---
+story_id: "3.1"
+depends_on: ["2.1"]
+---
+`)
+	parsed, err := sprint.ParseEpicsFileFull(path)
+	if err != nil {
+		t.Fatalf("ParseEpicsFileFull: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := planner.PlanWithEpics(ctx, parsed.Epics, parsed.Stories, 10); err != nil {
+		t.Fatalf("PlanWithEpics: %v", err)
+	}
+
+	depsStore := sqlite.NewStoryDependenciesStore(db)
+
+	// Story 2.1: 1.1 is the author's explicit depends_on; 1.2 is the
+	// epic_synth (Epic 2 requires_epics: [1], so the LAST story of Epic 1
+	// = 1.2 gets synthesised on every story in Epic 2 that didn't already
+	// pin it). 2.1 still has 1.1 from depends_on plus 1.2 from synthesis
+	// — verify both rows + both kinds.
+	edges21, err := depsStore.EdgesOf(ctx, "2.1")
+	if err != nil {
+		t.Fatalf("EdgesOf 2.1: %v", err)
+	}
+	got21 := edgeMap(edges21)
+	if got21["1.1"] != state.EdgeKindExplicit {
+		t.Errorf("2.1 → 1.1 should be explicit (author depends_on), got %q (map=%v)",
+			got21["1.1"], got21)
+	}
+	if got21["1.2"] != state.EdgeKindEpicSynth {
+		t.Errorf("2.1 → 1.2 should be epic_synth (Epic 2 requires_epics: [1] last-of=1.2), got %q (map=%v)",
+			got21["1.2"], got21)
+	}
+
+	// Story 3.1: depends_on ["2.1"] = explicit; requires_stories: ["1.2"]
+	// at Epic 3 header → 1.2 = epic_synth_stories.
+	edges31, err := depsStore.EdgesOf(ctx, "3.1")
+	if err != nil {
+		t.Fatalf("EdgesOf 3.1: %v", err)
+	}
+	got31 := edgeMap(edges31)
+	if got31["2.1"] != state.EdgeKindExplicit {
+		t.Errorf("3.1 → 2.1 should be explicit, got %q (map=%v)", got31["2.1"], got31)
+	}
+	if got31["1.2"] != state.EdgeKindEpicSynthStories {
+		t.Errorf("3.1 → 1.2 should be epic_synth_stories, got %q (map=%v)", got31["1.2"], got31)
+	}
+
+	// QuerySyntheticEdges must surface only the synth rows (no explicit
+	// rows leak through — that's the basis of validate-deps suppression).
+	synth, err := sqlite.QuerySyntheticEdges(ctx, db)
+	if err != nil {
+		t.Fatalf("QuerySyntheticEdges: %v", err)
+	}
+	for _, e := range synth {
+		if e.Kind == state.EdgeKindExplicit {
+			t.Errorf("QuerySyntheticEdges leaked an explicit row: %+v", e)
+		}
+	}
+}
+
+// TestStoryDependencies_AddDefaultsToExplicit confirms the back-compat
+// contract — the pre-#54 Add entry point keeps writing the 'explicit'
+// kind so legacy callers never accidentally produce synth-tagged rows.
+func TestStoryDependencies_AddDefaultsToExplicit(t *testing.T) {
+	t.Parallel()
+	db := openDB(t)
+	stories := sqlite.NewStoriesStore(db)
+	ctx := context.Background()
+	for _, id := range []string{"a", "b"} {
+		if err := stories.Insert(ctx, state.Story{
+			ID: id, File: id, Title: id,
+			Status: state.StatusPending, Complexity: state.ComplexityMedium,
+		}); err != nil {
+			t.Fatalf("insert %q: %v", id, err)
+		}
+	}
+	deps := sqlite.NewStoryDependenciesStore(db)
+	if err := deps.Add(ctx, "a", "b"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	edges, _ := deps.EdgesOf(ctx, "a")
+	if len(edges) != 1 || edges[0].Kind != state.EdgeKindExplicit {
+		t.Fatalf("Add() default kind = %v, want exactly 1 row with %q",
+			edges, state.EdgeKindExplicit)
+	}
+}
+
+// edgeMap projects a slice of DependencyEdge into dep-id → kind for
+// terse map-comparison assertions in mixed-kind tests.
+func edgeMap(edges []state.DependencyEdge) map[string]state.DependencyEdgeKind {
+	out := make(map[string]state.DependencyEdgeKind, len(edges))
+	for _, e := range edges {
+		out[e.DependsOnID] = e.Kind
+	}
+	return out
 }
 
 // equalStringSlices: order-sensitive equality, since SynthesizeRequiresEpics

--- a/application/sprint/validate.go
+++ b/application/sprint/validate.go
@@ -69,6 +69,30 @@ type ValidateReport struct {
 	TotalStories int `json:"total_stories"`
 }
 
+// SyntheticEdgeSet records edges the planner produced from epic-level
+// synthesis (issue #46 `requires_epics:` / `requires_stories:`) — keyed
+// by (story id, depends_on id) so a lookup is O(1). The validator's
+// placeholder-smell detector consults this to SUPPRESS warnings for
+// rows that came from epic-level intent rather than story-author
+// guesswork.
+//
+// The cobra wrapper populates this from the DB's `story_dependencies.
+// edge_kind` column post-#54 — the source of truth is now persistent
+// rather than re-derived from epic headers.
+type SyntheticEdgeSet map[string]map[string]bool
+
+// Has reports whether (storyID, depID) is a synthesised edge.
+func (s SyntheticEdgeSet) Has(storyID, depID string) bool {
+	if s == nil {
+		return false
+	}
+	deps, ok := s[storyID]
+	if !ok {
+		return false
+	}
+	return deps[depID]
+}
+
 // ValidateOptions parameterises a Validate call. Kept as a struct (not
 // positional args) so additive fields don't break callers.
 type ValidateOptions struct {
@@ -83,16 +107,17 @@ type ValidateOptions struct {
 	// errors so the caller exits non-zero. Other severities are unchanged.
 	Strict bool
 
-	// EpicRequires maps "epic id" → list of declared upstream epic ids
-	// it depends on (the future #46 `requires_epics:` field at the epic
-	// header). Used by the placeholder-smell detector to SUPPRESS the
-	// finding when "first story of Epic N depends_on last story of Epic
-	// N-1" matches an explicit `requires_epics: [N-1]` declaration.
+	// SyntheticEdges is the set of (story_id, dep_id) tuples that were
+	// produced by epic-level synthesis (issue #46) — the planner persists
+	// them with edge_kind = 'epic_synth' / 'epic_synth_stories'. The
+	// placeholder-smell detector treats any matching edge as legitimately
+	// epic-declared and suppresses the smell.
 	//
-	// Nil map = no declarations parsed; every "linear-chain" pattern
-	// will be flagged. Once #46 lands, the cobra wrapper populates this
-	// from epic-level frontmatter.
-	EpicRequires map[string][]string
+	// Nil = "no synthesis context available"; the detector falls back to
+	// flagging every linear-chain pattern (current behaviour for callers
+	// that don't have DB access). Issue #54 made this the canonical
+	// suppression source.
+	SyntheticEdges SyntheticEdgeSet
 }
 
 // Validate runs every detector over the parsed stories and returns a
@@ -123,7 +148,7 @@ func Validate(parsed []ParsedStory, opts ValidateOptions) ValidateReport {
 	findings = append(findings, detectMissingDeps(byID, order)...)
 	findings = append(findings, detectCycles(byID, order)...)
 	findings = append(findings, detectOrphans(byID, order)...)
-	findings = append(findings, detectPlaceholderSmell(byID, order, opts.EpicRequires)...)
+	findings = append(findings, detectPlaceholderSmell(byID, order, opts.SyntheticEdges)...)
 	findings = append(findings, detectDiamonds(byID, order)...)
 
 	// Deterministic ordering: kind alpha, then involved_ids[0] alpha.
@@ -469,16 +494,20 @@ func parseStoryNumber(s string) (int, bool) {
 // noise the operator can then clear, because the cost of a missed real
 // cross-epic dep is much higher than the cost of an extra INFO line.
 //
-// Suppression: when EpicRequires[N] contains "N-1", we skip the finding
-// (the operator has explicitly declared the cross-epic relationship at
-// the epic level, so the linear-chain frontmatter is intentional, not
-// a placeholder).
+// Suppression (post-#54): when the (story, dep) tuple is in syntheticEdges
+// — i.e. the planner persisted it as edge_kind != 'explicit' — we skip
+// the finding. The author has explicitly declared the cross-epic
+// relationship at the epic level, so the linear-chain SHAPE is
+// intentional, not a placeholder. This replaces the pre-#54 epic-id-keyed
+// EpicRequires map: we now suppress based on what the planner ACTUALLY
+// persisted, not on what the parser re-derived from the epic header.
 //
-// Defensive code path for #46: if EpicRequires is nil OR lacks an entry
-// for Epic N, we emit the finding. Once #46 lands and the cobra wrapper
-// populates the map from epic-level frontmatter, declarations will start
-// suppressing matches without any change to the detector.
-func detectPlaceholderSmell(byID map[string]ParsedStory, order []string, epicRequires map[string][]string) []Finding {
+// Backwards-compat: if syntheticEdges is nil (a caller that hasn't been
+// updated, or one running without DB access), every linear-chain pattern
+// gets the INFO finding — same conservative behaviour as before. The
+// suggested-fix text steers the operator at the docs that explain how
+// to declare requires_epics.
+func detectPlaceholderSmell(byID map[string]ParsedStory, order []string, syntheticEdges SyntheticEdgeSet) []Finding {
 	// Group ids by epic.
 	byEpic := make(map[string][]string)
 	for _, id := range order {
@@ -526,8 +555,10 @@ func detectPlaceholderSmell(byID map[string]ParsedStory, order []string, epicReq
 		if lastOfEpic[depEpic] != dep {
 			continue
 		}
-		// Suppression — explicit requires_epics declaration.
-		if declared := epicRequires[epic]; containsString(declared, depEpic) {
+		// Suppression — the planner persisted this edge as synthesised
+		// (issue #54), so it's an epic-level declaration rather than a
+		// story-author placeholder.
+		if syntheticEdges.Has(id, dep) {
 			continue
 		}
 		out = append(out, Finding{
@@ -556,15 +587,6 @@ func isPreviousEpicNumeric(epic, prevCandidate string) bool {
 		return false
 	}
 	return b == a-1
-}
-
-func containsString(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
 }
 
 // detectDiamonds flags ids that have ≥2 distinct dependency-paths

--- a/application/sprint/validate_test.go
+++ b/application/sprint/validate_test.go
@@ -190,12 +190,17 @@ func TestValidate_PlaceholderSmellSuppressedByRequiresEpics(t *testing.T) {
 		mkStory("2.1", "1.2"),
 		mkStory("2.2", "2.1"),
 	}
+	// Post-#54: suppression is driven by the (story, dep) edge having
+	// been persisted as synthesised. We feed that shape here directly so
+	// the test is independent of the planner.
 	rep := sprint.Validate(parsed, sprint.ValidateOptions{
-		EpicRequires: map[string][]string{"2": {"1"}},
+		SyntheticEdges: sprint.SyntheticEdgeSet{
+			"2.1": {"1.2": true},
+		},
 	})
 	kinds := findKinds(rep)
 	if kinds[sprint.FindingPlaceholderSmell] != 0 {
-		t.Fatalf("placeholder_smell should be suppressed by requires_epics, got %+v\n%+v",
+		t.Fatalf("placeholder_smell should be suppressed by synthesised edge, got %+v\n%+v",
 			kinds, rep.Findings)
 	}
 }

--- a/cmd/sprint_validate_deps.go
+++ b/cmd/sprint_validate_deps.go
@@ -84,19 +84,22 @@ Exit codes (` + "`bmad doctor`" + ` shows the full contract):
 				return err
 			}
 
+			// Post-#54: consult the state DB for any edges the planner
+			// has already persisted as synthesised (edge_kind !=
+			// 'explicit'). Each such edge suppresses the placeholder-
+			// smell finding on the matching (story, dep) pair.
+			//
+			// Failure modes: when the DB isn't reachable (fresh repo
+			// pre-`bmad sprint plan`), or when no rows have been written
+			// yet, we proceed with a nil edge set — every linear-chain
+			// pattern still emits the INFO finding, same conservative
+			// behaviour as the pre-#54 nil EpicRequires path.
+			syntheticEdges := loadSyntheticEdges(ctx)
+
 			report := appsprint.Validate(parsed, appsprint.ValidateOptions{
-				Scope:  scope,
-				Strict: strict,
-				// EpicRequires intentionally nil for now — issue #46 will
-				// add epic-level frontmatter parsing. When it does, this
-				// is the single place to wire it in:
-				//
-				//   EpicRequires: appsprint.ParseEpicRequires(epicsPath),
-				//
-				// Until then, every "first-of-epic depends_on last-of-prev"
-				// match emits a placeholder_smell INFO finding (the
-				// suggestion text tells the operator how to fix it).
-				EpicRequires: nil,
+				Scope:          scope,
+				Strict:         strict,
+				SyntheticEdges: syntheticEdges,
 			})
 
 			if jsonOutput {
@@ -128,6 +131,42 @@ Exit codes (` + "`bmad doctor`" + ` shows the full contract):
 	cmd.Flags().StringVar(&scope, "scope", "", "restrict validation to one epic id (e.g. 4 → only 4.* stories)")
 	cmd.Flags().BoolVar(&strict, "strict", false, "escalate WARN findings (orphans) to errors for the exit-code decision")
 	return cmd
+}
+
+// loadSyntheticEdges queries the state DB for every story_dependencies row
+// whose edge_kind marks it as a synth product of issue #46 / #54 epic-
+// level resolution, and returns them shaped for the validator's
+// suppression lookup. Errors are swallowed deliberately — a fresh repo
+// without a DB on disk simply gets a nil set, the same defensive default
+// every other code path uses for "no DB context available".
+//
+// This is what makes `bmad sprint validate-deps` distinguish a story
+// author's depends_on placeholder from a planner-synthesised edge: the
+// DB is the single source of truth for that distinction, and the row
+// shape on disk is what we read here.
+func loadSyntheticEdges(ctx context.Context) appsprint.SyntheticEdgeSet {
+	db, err := openV6DB(ctx)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+	rows, err := sqlite.QuerySyntheticEdges(ctx, db)
+	if err != nil {
+		return nil
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make(appsprint.SyntheticEdgeSet, len(rows))
+	for _, r := range rows {
+		inner := out[r.StoryID]
+		if inner == nil {
+			inner = make(map[string]bool, 2)
+			out[r.StoryID] = inner
+		}
+		inner[r.DependsOnID] = true
+	}
+	return out
 }
 
 // emitValidateText renders a short human-readable summary. JSON callers

--- a/domain/state/stories.go
+++ b/domain/state/stories.go
@@ -61,9 +61,66 @@ type Stories interface {
 	ReapStaleClaims(ctx context.Context, ttlSeconds int) ([]string, error)
 }
 
+// DependencyEdgeKind classifies how a story_dependencies row entered the
+// table — pre-#54 every row was implicitly "explicit" (a story author's
+// own depends_on declaration). Issue #54 adds two synthesised kinds so
+// downstream consumers (graph viz, validate-deps) can distinguish them.
+//
+// Kept as a string-typed alias rather than an int enum so the on-disk
+// representation is human-readable and we can introduce new kinds (e.g.
+// "infer_deps_prose") without bumping a schema version.
+type DependencyEdgeKind string
+
+const (
+	// EdgeKindExplicit — story-level `depends_on: [...]` declaration.
+	// This is the migration default for back-filled rows so pre-#54
+	// behaviour is preserved.
+	EdgeKindExplicit DependencyEdgeKind = "explicit"
+	// EdgeKindEpicSynth — synthesised by the issue #46 resolver from an
+	// epic header's `requires_epics: [N]` field.
+	EdgeKindEpicSynth DependencyEdgeKind = "epic_synth"
+	// EdgeKindEpicSynthStories — synthesised from an epic header's
+	// `requires_stories: [...]` field. Distinct from EdgeKindEpicSynth so
+	// findings + visualisations can attribute it precisely; both kinds
+	// share the dashed-line treatment in `bmad sprint graph`.
+	EdgeKindEpicSynthStories DependencyEdgeKind = "epic_synth_stories"
+)
+
+// IsSynthesized reports whether the kind came from epic-level synthesis
+// (vs. story-author intent). Used by `bmad sprint validate-deps` to
+// suppress the placeholder-smell finding for synthesised edges and by
+// `bmad sprint graph` to pick dashed rendering.
+func (k DependencyEdgeKind) IsSynthesized() bool {
+	switch k {
+	case EdgeKindEpicSynth, EdgeKindEpicSynthStories:
+		return true
+	default:
+		return false
+	}
+}
+
+// DependencyEdge is one (story → prerequisite) tuple with its source kind.
+// Surface this struct only when a consumer needs the kind — story-status
+// consumers that just want the prereq ids continue to use `Of`.
+type DependencyEdge struct {
+	StoryID     string
+	DependsOnID string
+	Kind        DependencyEdgeKind
+}
+
 // StoryDependencies is the m:n bridge between a story and its prerequisites.
 type StoryDependencies interface {
+	// Add inserts an explicit (story-level depends_on) edge. Kept for the
+	// pre-#54 call sites that don't carry an edge-kind context (raw CRUD
+	// adapters, manual repair tooling); the planner uses AddWithKind to
+	// preserve synthesis attribution.
 	Add(ctx context.Context, storyID, dependsOnID string) error
+	// AddWithKind inserts a tagged edge — used by the planner so synth
+	// edges are distinguishable from explicit ones at read time. Idempotent
+	// against the (story_id, depends_on_id) primary key; existing rows are
+	// left untouched (kind is NOT overwritten on conflict so a manually-
+	// promoted edge is never silently demoted).
+	AddWithKind(ctx context.Context, storyID, dependsOnID string, kind DependencyEdgeKind) error
 	Remove(ctx context.Context, storyID, dependsOnID string) error
 	// RemoveAllFor deletes every dependency edge for storyID. Used by
 	// `bmad sprint plan` to make re-ingest idempotent: when an operator
@@ -74,6 +131,9 @@ type StoryDependencies interface {
 	// No-op (not an error) if the story has no dependency rows.
 	RemoveAllFor(ctx context.Context, storyID string) error
 	Of(ctx context.Context, storyID string) ([]string, error)
+	// EdgesOf returns the dependency rows for storyID with their kinds.
+	// Sorted by depends_on_id ascending for deterministic output.
+	EdgesOf(ctx context.Context, storyID string) ([]DependencyEdge, error)
 	DependentsOf(ctx context.Context, storyID string) ([]string, error)
 }
 

--- a/infrastructure/state/sqlite/schema/0005_story_dependencies_edge_kind.down.sql
+++ b/infrastructure/state/sqlite/schema/0005_story_dependencies_edge_kind.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE story_dependencies DROP COLUMN edge_kind;

--- a/infrastructure/state/sqlite/schema/0005_story_dependencies_edge_kind.up.sql
+++ b/infrastructure/state/sqlite/schema/0005_story_dependencies_edge_kind.up.sql
@@ -1,0 +1,33 @@
+-- Migration 0005 — edge_kind column on story_dependencies (issue #54).
+--
+-- Discriminates how each dependency edge entered the table:
+--
+--   'explicit'           — story author's own `depends_on: [...]` declaration
+--                          (the only flavour that existed pre-#46; default
+--                          for backward compatibility so existing rows keep
+--                          behaving as story-level deps without re-ingest)
+--   'epic_synth'         — synthesised by the issue #46 resolver from an
+--                          epic-level `requires_epics: [N]` declaration —
+--                          renders as a dashed line in `bmad sprint graph`
+--   'epic_synth_stories' — synthesised from an epic-level
+--                          `requires_stories: [...]` declaration (literal
+--                          cross-cutting story pins); also dashed
+--
+-- Storage:
+--
+--   * TEXT (not an enum) to stay future-proof if a new synthesis source
+--     emerges — existing readers fall back to the default styling for
+--     unknown kinds, never error.
+--   * NOT NULL DEFAULT 'explicit' so the column is fully defined for every
+--     row the moment the ALTER runs; SQLite back-fills existing rows with
+--     the default, preserving behaviour for callers that haven't been
+--     touched by the planner since the migration.
+--
+-- Idempotency: SQLite's ALTER TABLE ... ADD COLUMN errors on re-run, so the
+-- migration runner's schema_version gate is what makes the migration
+-- effectively idempotent (an already-applied version is skipped). This file
+-- itself is a single atomic ALTER inside the migration transaction, so a
+-- mid-run crash leaves the schema either fully at v4 or fully at v5 — never
+-- partially mutated.
+
+ALTER TABLE story_dependencies ADD COLUMN edge_kind TEXT NOT NULL DEFAULT 'explicit';

--- a/infrastructure/state/sqlite/story_relations.go
+++ b/infrastructure/state/sqlite/story_relations.go
@@ -15,11 +15,29 @@ func NewStoryDependenciesStore(db *DB) *StoryDependenciesStore {
 }
 
 func (s *StoryDependenciesStore) Add(ctx context.Context, storyID, dependsOnID string) error {
+	// Pre-#54 entry point — defaults to the 'explicit' kind so callers that
+	// don't carry synthesis context (manual repair tooling, raw CRUD)
+	// preserve the historical semantics.
+	return s.AddWithKind(ctx, storyID, dependsOnID, state.EdgeKindExplicit)
+}
+
+// AddWithKind inserts a tagged edge. INSERT OR IGNORE keeps the call
+// idempotent against the (story_id, depends_on_id) primary key — when a
+// row already exists we deliberately do NOT overwrite its edge_kind. This
+// means a row previously written as 'explicit' (e.g. by a story author's
+// depends_on) wins over a later 'epic_synth' that points at the same
+// upstream story; the planner's wipe-then-replace flow (RemoveAllFor +
+// AddWithKind) guarantees the right kind on every re-ingest, so this
+// preserve-on-conflict policy is only the safety net.
+func (s *StoryDependenciesStore) AddWithKind(ctx context.Context, storyID, dependsOnID string, kind state.DependencyEdgeKind) error {
+	if kind == "" {
+		kind = state.EdgeKindExplicit
+	}
 	_, err := s.db.sqlDB().ExecContext(ctx,
-		`INSERT OR IGNORE INTO story_dependencies (story_id, depends_on_id) VALUES (?, ?)`,
-		storyID, dependsOnID)
+		`INSERT OR IGNORE INTO story_dependencies (story_id, depends_on_id, edge_kind) VALUES (?, ?, ?)`,
+		storyID, dependsOnID, string(kind))
 	if err != nil {
-		return fmt.Errorf("story_dependencies add %q->%q: %w", storyID, dependsOnID, err)
+		return fmt.Errorf("story_dependencies add %q->%q (%s): %w", storyID, dependsOnID, kind, err)
 	}
 	return nil
 }
@@ -52,10 +70,69 @@ func (s *StoryDependenciesStore) Of(ctx context.Context, storyID string) ([]stri
 		storyID)
 }
 
+// EdgesOf returns each dependency row for storyID with its edge_kind, sorted
+// deterministically by depends_on_id. Consumers that need the kind (graph
+// renderer, validate-deps placeholder suppression) call this; consumers
+// that only care about the prereq id list keep using `Of` to avoid a kind
+// allocation per row.
+func (s *StoryDependenciesStore) EdgesOf(ctx context.Context, storyID string) ([]state.DependencyEdge, error) {
+	rows, err := s.db.sqlDB().QueryContext(ctx,
+		`SELECT depends_on_id, edge_kind FROM story_dependencies
+		 WHERE story_id = ? ORDER BY depends_on_id`,
+		storyID)
+	if err != nil {
+		return nil, fmt.Errorf("story_dependencies edges-of %q: %w", storyID, err)
+	}
+	defer rows.Close()
+	var out []state.DependencyEdge
+	for rows.Next() {
+		e := state.DependencyEdge{StoryID: storyID}
+		var kind string
+		if err := rows.Scan(&e.DependsOnID, &kind); err != nil {
+			return nil, fmt.Errorf("story_dependencies edges-of %q scan: %w", storyID, err)
+		}
+		e.Kind = state.DependencyEdgeKind(kind)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 func (s *StoryDependenciesStore) DependentsOf(ctx context.Context, storyID string) ([]string, error) {
 	return queryIDs(ctx, s.db,
 		`SELECT story_id FROM story_dependencies WHERE depends_on_id = ? ORDER BY story_id`,
 		storyID)
+}
+
+// QuerySyntheticEdges returns every story_dependencies row whose edge_kind
+// is not 'explicit' — i.e. the rows the planner wrote from epic-level
+// synthesis (issue #46) and tagged via #54. The caller (validate-deps cobra
+// shim) reshapes the slice into a SyntheticEdgeSet for the validator.
+//
+// Lives as a package-level function (not a method on StoryDependenciesStore)
+// because the consumer doesn't otherwise need the store — keeping the call
+// site free of an unused adapter handle. Returns an empty slice (no error)
+// when the table is empty; a non-existent column would surface at migration
+// time, never here.
+func QuerySyntheticEdges(ctx context.Context, db *DB) ([]state.DependencyEdge, error) {
+	rows, err := db.sqlDB().QueryContext(ctx,
+		`SELECT story_id, depends_on_id, edge_kind FROM story_dependencies
+		 WHERE edge_kind != ? ORDER BY story_id, depends_on_id`,
+		string(state.EdgeKindExplicit))
+	if err != nil {
+		return nil, fmt.Errorf("query synthetic edges: %w", err)
+	}
+	defer rows.Close()
+	var out []state.DependencyEdge
+	for rows.Next() {
+		var e state.DependencyEdge
+		var kind string
+		if err := rows.Scan(&e.StoryID, &e.DependsOnID, &kind); err != nil {
+			return nil, fmt.Errorf("query synthetic edges scan: %w", err)
+		}
+		e.Kind = state.DependencyEdgeKind(kind)
+		out = append(out, e)
+	}
+	return out, rows.Err()
 }
 
 // StoryAffectsStore — sqlite adapter for state.StoryAffects.


### PR DESCRIPTION
## Summary

- Adds `edge_kind TEXT NOT NULL DEFAULT 'explicit'` to `story_dependencies` (migration 0005) so synth-from-epic-requires edges are distinguishable from story-level explicit deps.
- Planner persists the right kind per row (`explicit` / `epic_synth` / `epic_synth_stories`).
- `bmad sprint graph` now actually emits the dashed lines its renderer was already coded for — the `EdgeKindEpicSynth` hook from PR #53 is finally wired to the data.
- `bmad sprint validate-deps` reads the column to suppress placeholder-smell on synth edges, replacing the parser-derived `EpicRequires` map.

Closes #54.

## What this unblocks

The dashed-edge rendering in `bmad sprint graph` that was coded into PR #53 but had no data source. Operators reviewing the sprint DAG can now visually distinguish "this story author wrote depends_on" from "the resolver synthesised this from a requires_epics declaration."

## Acceptance criteria

| # | AC                                                        | Status |
|---|-----------------------------------------------------------|--------|
| 1 | Migration adds `edge_kind`, defaults existing rows        | done   |
| 2 | `SynthesizeRequiresEpics` writes correct kind on synth   | done   |
| 3 | `sprint graph` renders synth as dashed lines             | done   |
| 4 | `validate-deps` placeholder-smell driven by the column   | done   |
| 5 | Backwards compat for explicit-only DAGs                  | done   |
| 6 | 4-epic fixture asserts column values                     | done   |

## Live verification

```text
$ bmad sprint plan --epics docs/epics.md
{"stories_inserted":7,"dependencies_added":8,"synthesized_dependencies_added":6,...}

$ sqlite3 bmad-state.db "SELECT story_id, depends_on_id, edge_kind FROM story_dependencies ORDER BY story_id"
2.1|1.1|explicit
2.1|1.3|epic_synth
2.2|1.3|epic_synth
3.1|1.2|epic_synth_stories
3.1|1.3|epic_synth
3.1|2.1|explicit
3.2|1.2|epic_synth_stories
3.2|1.3|epic_synth

$ bmad sprint graph --format dot --with-status=false
digraph sprint {
  ...
  "2.1" -> "1.1";
  "2.1" -> "1.3" [style=dashed];
  "2.2" -> "1.3" [style=dashed];
  "3.1" -> "1.2" [style=dashed];
  "3.1" -> "2.1";
  "3.2" -> "1.2" [style=dashed];
}
```

## Design notes

- The `Add()` entry point on `state.StoryDependencies` is preserved (defaults to `explicit`) so legacy callers (v4-migrate importer, raw CRUD) keep their semantics. The planner uses the new `AddWithKind` so attribution flows through.
- Synth attribution wins on conflict: when a story author wrote `depends_on: [X]` for a target that the resolver would have synthesised anyway, the row is tagged with the synth kind. This is what makes the placeholder-smell suppression align with the issue's contract ("suppress for any edge with edge_kind != explicit").
- `SynthesizeRequiresEpics` no longer dedupes synth edges against author depends_on — the planner's combine-step is now the single place that decides what counts as a "new edge" for the `SynthesizedDependenciesAdded` counter.
- `ValidateOptions.EpicRequires` is removed and replaced by `SyntheticEdges`, populated from the DB. Pure-function callers (no DB access) get a nil set → conservative behaviour preserved.

## Test plan

- [x] `go test -short ./...` passes (full suite)
- [x] New tests: `TestPlanWithEpics_MixedExplicitAndSynthEdgeKinds`, `TestStoryDependencies_AddDefaultsToExplicit`, `TestRenderDOT_SynthEdgesAreDashed`, `TestRenderMermaid_SynthEdgesUseDashedArrow`
- [x] Existing 4-epic test enriched with per-row edge_kind assertions
- [x] `bmad sprint plan` + `bmad sprint graph` + `bmad sprint validate-deps` exercised end-to-end against a live state DB