### PR TITLE
fix(sprint): resume clears open checkpoint rows (closes #71 sub-4)

### DIFF
--- a/cmd/jsonout_test.go
+++ b/cmd/jsonout_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
@@ -338,6 +339,168 @@ func TestJSON_SprintPauseResume(t *testing.T) {
 	}
 	if resumeR["ok"] != true || resumeR["paused"] != false {
 		t.Errorf("resume result wrong: %+v", resumeR)
+	}
+}
+
+// TestJSON_SprintResume_ClearsUnresolvedCheckpoint is the issue #71 sub-4
+// regression guard. Pre-fix, `bmad sprint resume` only cleared
+// `sprint.paused` but left rows with `user_decision IS NULL` alone — so
+// the subsequent `bmad sprint status --json` re-surfaced
+// `unresolved_checkpoint` and the orchestrator loop spun on it forever.
+//
+// We exercise the full sequence the real orchestrator runs:
+//   1. seed a checkpoint with user_decision = NULL (Fire())
+//   2. assert sprint status surfaces it under unresolved_checkpoint
+//   3. invoke `bmad sprint resume`
+//   4. assert sprint status now reports unresolved_checkpoint = null
+//   5. assert the underlying row was stamped with decision="continue"
+func TestJSON_SprintResume_ClearsUnresolvedCheckpoint(t *testing.T) {
+	dbPath := seedStoriesForJSON(t)
+
+	// Step 1 — fire an open checkpoint directly through the port (mirrors
+	// what the §12.5 dual-trigger does inside the orchestrator).
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	checkpoints := sqlite.NewCheckpointsStore(db)
+	idemKey := "count:21:7.4"
+	id, err := checkpoints.Fire(ctx, state.Checkpoint{
+		TriggerKind:      state.CheckpointCount,
+		StoriesSinceLast: 21,
+		SummaryJSON:      `{}`,
+		IdempotencyKey:   &idemKey,
+	})
+	if err != nil {
+		t.Fatalf("Fire checkpoint: %v", err)
+	}
+	db.Close()
+
+	// Step 2 — confirm `sprint status --json` surfaces the open checkpoint.
+	envBefore, _ := runCmdJSONCapture(t, dbPath, "sprint", "status")
+	commonEnvelopeAssertions(t, envBefore, "sprint status")
+	var beforeR map[string]any
+	if err := json.Unmarshal(envBefore.Result, &beforeR); err != nil {
+		t.Fatalf("status-before unmarshal: %v", err)
+	}
+	if beforeR["unresolved_checkpoint"] == nil {
+		t.Fatalf("before resume: unresolved_checkpoint should be non-nil, got %+v",
+			beforeR["unresolved_checkpoint"])
+	}
+
+	// Step 3 — `bmad sprint resume` should clear paused AND resolve the
+	// checkpoint. Pre-fix, only `paused` was cleared.
+	envResume, _ := runCmdJSONCapture(t, dbPath, "sprint", "resume")
+	commonEnvelopeAssertions(t, envResume, "sprint resume")
+	var resumeR map[string]any
+	if err := json.Unmarshal(envResume.Result, &resumeR); err != nil {
+		t.Fatalf("resume unmarshal: %v", err)
+	}
+	if resumeR["ok"] != true || resumeR["paused"] != false {
+		t.Errorf("resume result: ok/paused wrong: %+v", resumeR)
+	}
+	if resumeR["checkpoints_resolved"] != float64(1) {
+		t.Errorf("checkpoints_resolved = %v, want 1", resumeR["checkpoints_resolved"])
+	}
+	if resumeR["checkpoint_decision"] != "continue" {
+		t.Errorf("checkpoint_decision = %v, want \"continue\"", resumeR["checkpoint_decision"])
+	}
+
+	// Step 4 — `sprint status --json` must now report unresolved_checkpoint
+	// = nil. This is the bug repro: pre-fix this still showed the row.
+	envAfter, _ := runCmdJSONCapture(t, dbPath, "sprint", "status")
+	commonEnvelopeAssertions(t, envAfter, "sprint status")
+	var afterR map[string]any
+	if err := json.Unmarshal(envAfter.Result, &afterR); err != nil {
+		t.Fatalf("status-after unmarshal: %v", err)
+	}
+	if afterR["unresolved_checkpoint"] != nil {
+		t.Errorf("after resume: unresolved_checkpoint should be nil, got %+v",
+			afterR["unresolved_checkpoint"])
+	}
+
+	// Step 5 — the row itself was stamped with decision="continue" + a
+	// non-nil decided_at. Verify directly through the port; this guards
+	// against future changes that "fix" the bug by hiding rather than
+	// resolving.
+	db2, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db2.Close()
+	cp, err := sqlite.NewCheckpointsStore(db2).Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get checkpoint %d: %v", id, err)
+	}
+	if cp.UserDecision == nil || *cp.UserDecision != state.DecisionContinue {
+		t.Errorf("UserDecision = %v, want %q", cp.UserDecision, state.DecisionContinue)
+	}
+	if cp.DecidedAt == nil {
+		t.Errorf("DecidedAt nil, want non-nil")
+	}
+}
+
+// TestJSON_SprintResume_NoCheckpoints_NoError ensures resume is a no-op
+// (not an error) when no checkpoints are open — the common case where
+// resume just clears `sprint.paused`.
+func TestJSON_SprintResume_NoCheckpoints_NoError(t *testing.T) {
+	dbPath := seedStoriesForJSON(t)
+	env, _ := runCmdJSONCapture(t, dbPath, "sprint", "resume")
+	commonEnvelopeAssertions(t, env, "sprint resume")
+	var r map[string]any
+	if err := json.Unmarshal(env.Result, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r["checkpoints_resolved"] != float64(0) {
+		t.Errorf("checkpoints_resolved = %v, want 0", r["checkpoints_resolved"])
+	}
+}
+
+// TestJSON_SprintResume_MultipleCheckpoints_AllCleared exercises the
+// documented "resume clears ALL open checkpoints" rule. If a sprint
+// somehow accrues multiple NULL-user_decision rows (e.g. count + complexity
+// fired before the operator could respond), one resume call clears them
+// all rather than requiring N invocations.
+func TestJSON_SprintResume_MultipleCheckpoints_AllCleared(t *testing.T) {
+	dbPath := seedStoriesForJSON(t)
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	cps := sqlite.NewCheckpointsStore(db)
+	for i, kind := range []state.CheckpointTrigger{state.CheckpointCount, state.CheckpointComplexity} {
+		k := kind
+		key := string(k) + ":seed:" + strconv.Itoa(i)
+		if _, err := cps.Fire(ctx, state.Checkpoint{
+			TriggerKind:      k,
+			StoriesSinceLast: i,
+			SummaryJSON:      `{}`,
+			IdempotencyKey:   &key,
+		}); err != nil {
+			t.Fatalf("seed checkpoint %d: %v", i, err)
+		}
+	}
+	db.Close()
+
+	env, _ := runCmdJSONCapture(t, dbPath, "sprint", "resume")
+	commonEnvelopeAssertions(t, env, "sprint resume")
+	var r map[string]any
+	if err := json.Unmarshal(env.Result, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r["checkpoints_resolved"] != float64(2) {
+		t.Errorf("checkpoints_resolved = %v, want 2 (all open rows cleared)",
+			r["checkpoints_resolved"])
+	}
+
+	// Confirm zero remain unresolved.
+	db2, _ := sqlite.Open(ctx, dbPath)
+	defer db2.Close()
+	left, _ := sqlite.NewCheckpointsStore(db2).Unresolved(ctx)
+	if left != nil {
+		t.Errorf("Unresolved after multi-resume = %+v, want nil", left)
 	}
 }
 

--- a/cmd/sprint.go
+++ b/cmd/sprint.go
@@ -270,10 +270,29 @@ func newSprintPauseCmd() *cobra.Command {
 
 // ---------- resume ----------
 
+// newSprintResumeCmd unpauses the sprint AND clears any open §12.5
+// checkpoint rows (issue #71).
+//
+// Why both in one command: prior to this fix, `bmad sprint resume` only
+// cleared `sprint.paused` but left `user_decision IS NULL` rows alone, so
+// the very next `bmad sprint status --json` re-surfaced
+// `unresolved_checkpoint` and the orchestrator loop would call `resume`
+// again on each iteration without making forward progress.
+//
+// Decision stamped: `state.DecisionContinue` — the operator running
+// `sprint resume` is implicitly declaring "I want to proceed past this
+// halt". Operators who instead want `adjust` or `halt` should use
+// `bmad checkpoint decide` (or its successor) directly — this command is
+// the happy-path shortcut for the most common case.
+//
+// All-or-most-recent rule: ResolveAllUnresolved stamps every NULL row in a
+// single UPDATE. We choose ALL (not just MAX(id)) because a sprint with
+// multiple stuck checkpoints would otherwise need N resume calls to clear;
+// the orchestrator can re-Fire if it genuinely needs a new halt.
 func newSprintResumeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "resume",
-		Short: "Clear sprint.paused; resume orchestrator on next invocation",
+		Short: "Clear sprint.paused + resolve any open §12.5 checkpoint rows (issue #71)",
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx := context.Background()
 			db, err := openV6DB(ctx)
@@ -285,11 +304,27 @@ func newSprintResumeCmd() *cobra.Command {
 			if err := cfg.Delete(ctx, sprintPausedKey); err != nil {
 				return err
 			}
+			checkpoints := sqlite.NewCheckpointsStore(db)
+			cleared, err := checkpoints.ResolveAllUnresolved(ctx,
+				state.DecisionContinue, time.Now().UTC())
+			if err != nil {
+				return fmt.Errorf("sprint resume: resolve checkpoints: %w", err)
+			}
 			if jsonOutput {
 				return emitJSONStdout(commandPathSansRoot(c), nil,
-					map[string]any{"ok": true, "paused": false}, nil)
+					map[string]any{
+						"ok":                    true,
+						"paused":                false,
+						"checkpoints_resolved":  cleared,
+						"checkpoint_decision":   string(state.DecisionContinue),
+					}, nil)
 			}
-			fmt.Println("sprint resumed")
+			if cleared > 0 {
+				fmt.Printf("sprint resumed (cleared %d open checkpoint(s) → %s)\n",
+					cleared, state.DecisionContinue)
+			} else {
+				fmt.Println("sprint resumed")
+			}
 			return nil
 		},
 	}

--- a/domain/state/checkpoints.go
+++ b/domain/state/checkpoints.go
@@ -8,10 +8,17 @@ import (
 // Checkpoints is the §12.5 dual-trigger record port. Fire writes a row with
 // user_decision = NULL; the orchestrator's next loop iteration HALTs on the
 // unresolved row, and Decide records the user's verdict.
+//
+// ResolveAllUnresolved is the bulk-clear used by `bmad sprint resume` (issue
+// #71). It stamps every NULL-user_decision row with the supplied decision in
+// a single statement so the orchestrator loop can't observe stale halt rows
+// after the operator has explicitly resumed. Returns the number of rows
+// affected (zero when no checkpoint was open — not an error).
 type Checkpoints interface {
 	Fire(ctx context.Context, c Checkpoint) (int64, error)
 	Get(ctx context.Context, id int64) (Checkpoint, error)
 	Unresolved(ctx context.Context) (*Checkpoint, error)
 	Decide(ctx context.Context, id int64, decision CheckpointDecision, when time.Time) error
+	ResolveAllUnresolved(ctx context.Context, decision CheckpointDecision, when time.Time) (int, error)
 	StoriesSinceLast(ctx context.Context) (int, error)
 }

--- a/infrastructure/state/sqlite/adapters_test.go
+++ b/infrastructure/state/sqlite/adapters_test.go
@@ -382,6 +382,73 @@ func TestCheckpoints_FireAndDecide(t *testing.T) {
 	}
 }
 
+// TestCheckpoints_ResolveAllUnresolved is the issue #71 sub-4 regression
+// guard at the port layer: a single call must stamp every NULL-decision
+// row, and re-calls (or empty-table calls) must be silent no-ops returning
+// zero — never an error.
+func TestCheckpoints_ResolveAllUnresolved(t *testing.T) {
+	t.Parallel()
+	db := newTempDB(t)
+	store := sqlite.NewCheckpointsStore(db)
+	ctx := context.Background()
+
+	// No-op when no rows.
+	if n, err := store.ResolveAllUnresolved(ctx, state.DecisionContinue, time.Now().UTC()); err != nil || n != 0 {
+		t.Fatalf("ResolveAll on empty: n=%d err=%v, want n=0 err=nil", n, err)
+	}
+
+	// Fire two open + one already-decided row.
+	d1 := "count:1"
+	d2 := "complexity:2"
+	d3 := "count:3-resolved"
+	id1, _ := store.Fire(ctx, state.Checkpoint{TriggerKind: state.CheckpointCount, StoriesSinceLast: 1, SummaryJSON: "{}", IdempotencyKey: &d1})
+	id2, _ := store.Fire(ctx, state.Checkpoint{TriggerKind: state.CheckpointComplexity, StoriesSinceLast: 2, SummaryJSON: "{}", IdempotencyKey: &d2})
+	id3, _ := store.Fire(ctx, state.Checkpoint{TriggerKind: state.CheckpointCount, StoriesSinceLast: 3, SummaryJSON: "{}", IdempotencyKey: &d3})
+	// Mark id3 as already decided so we can prove ResolveAll doesn't touch
+	// rows that aren't NULL.
+	if err := store.Decide(ctx, id3, state.DecisionAdjust, time.Now().UTC()); err != nil {
+		t.Fatalf("seed Decide id3: %v", err)
+	}
+
+	n, err := store.ResolveAllUnresolved(ctx, state.DecisionContinue, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("ResolveAll touched %d, want 2 (id1+id2; id3 was already decided)", n)
+	}
+
+	// id1 and id2 now stamped with continue.
+	for _, id := range []int64{id1, id2} {
+		cp, err := store.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get %d: %v", id, err)
+		}
+		if cp.UserDecision == nil || *cp.UserDecision != state.DecisionContinue {
+			t.Errorf("id=%d UserDecision = %v, want continue", id, cp.UserDecision)
+		}
+		if cp.DecidedAt == nil {
+			t.Errorf("id=%d DecidedAt nil", id)
+		}
+	}
+
+	// id3 still has its original adjust decision.
+	cp3, _ := store.Get(ctx, id3)
+	if cp3.UserDecision == nil || *cp3.UserDecision != state.DecisionAdjust {
+		t.Errorf("id3 decision changed: got %v, want adjust (ResolveAll must not overwrite)", cp3.UserDecision)
+	}
+
+	// Idempotency: re-running with no open rows is a zero-count no-op.
+	if n2, err := store.ResolveAllUnresolved(ctx, state.DecisionContinue, time.Now().UTC()); err != nil || n2 != 0 {
+		t.Fatalf("ResolveAll re-run: n=%d err=%v, want n=0 err=nil", n2, err)
+	}
+
+	// Final Unresolved query returns nil.
+	if u, _ := store.Unresolved(ctx); u != nil {
+		t.Errorf("Unresolved after ResolveAll = %+v, want nil", u)
+	}
+}
+
 // ---------- Depguard ----------
 
 func TestDepguard_FlipAndHistory(t *testing.T) {

--- a/infrastructure/state/sqlite/checkpoints.go
+++ b/infrastructure/state/sqlite/checkpoints.go
@@ -98,6 +98,26 @@ func (s *CheckpointsStore) Decide(ctx context.Context, id int64, decision state.
 	return nil
 }
 
+// ResolveAllUnresolved stamps every open (user_decision IS NULL) checkpoint
+// row with the supplied decision in a single UPDATE. Used by `bmad sprint
+// resume` (issue #71) so that resuming a paused sprint also clears any
+// pending halt rows — otherwise the next `sprint status --json` re-surfaces
+// the same checkpoint and the orchestrator spins on it forever.
+//
+// Returns the count of rows that transitioned from NULL → decision. Zero
+// rows is a normal, non-error outcome (no checkpoint was open).
+func (s *CheckpointsStore) ResolveAllUnresolved(ctx context.Context, decision state.CheckpointDecision, when time.Time) (int, error) {
+	res, err := s.db.sqlDB().ExecContext(ctx, `
+		UPDATE checkpoints SET user_decision = ?, decided_at = ?
+		WHERE user_decision IS NULL
+	`, string(decision), when)
+	if err != nil {
+		return 0, fmt.Errorf("checkpoints resolve-all: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 func (s *CheckpointsStore) StoriesSinceLast(ctx context.Context) (int, error) {
 	// "Since last checkpoint" = stories with completed_at > MAX(triggered_at).
 	// If no checkpoints exist yet, count all completed stories.


### PR DESCRIPTION
## Summary

Fixes issue 4 of #71. `bmad sprint resume` now resolves every open §12.5 checkpoint row with `decision = "continue"` after clearing `sprint.paused`. Before this fix, resume unpaused the sprint but left `user_decision IS NULL` rows alone — so the next `bmad sprint status --json` re-surfaced `unresolved_checkpoint` and the orchestrator loop spun on it forever without making forward progress.

- Adds `Checkpoints.ResolveAllUnresolved(ctx, decision, when) (int, error)` to the domain port
- SQLite implementation is a single `UPDATE` over `user_decision IS NULL` (atomic, clears all stuck rows in one call)
- Resume JSON envelope now carries `checkpoints_resolved` + `checkpoint_decision` so callers can see what happened
- All-not-MAX(id) rule is documented in code: multiple stuck checkpoints clear in one call rather than requiring N resume invocations

This is scoped to sub-issue 4 only. Sub-issues 1, 2, 3, 5 are owned by parallel agents.

## Before / after (manual CLI repro from the issue)

**Before fix (v0.5.0):** step 3 still showed the checkpoint with `UserDecision: null`.

**After fix:**
```
$ sqlite3 bmad-state.db "INSERT INTO checkpoints (...) VALUES ('count', 21, '{}', 'test-key-1')"
$ bmad --json sprint status | jq '.result.unresolved_checkpoint, .result.paused'
{ "ID": 1, "TriggerKind": "count", "StoriesSinceLast": 21, "UserDecision": null, ... }
true

$ bmad --json sprint resume | jq '.result'
{
  "checkpoint_decision": "continue",
  "checkpoints_resolved": 1,
  "ok": true,
  "paused": false
}

$ bmad --json sprint status | jq '.result.unresolved_checkpoint, .result.paused'
null
false
```

DB row state after resume: `user_decision = continue`, `decided_at` populated.

## Test plan

- [x] `TestCheckpoints_ResolveAllUnresolved` — port-level: multi-row clear, already-decided rows untouched, idempotent re-run
- [x] `TestJSON_SprintResume_ClearsUnresolvedCheckpoint` — full CLI repro from the issue (fire → status shows it → resume → status null → row stamped)
- [x] `TestJSON_SprintResume_NoCheckpoints_NoError` — zero-checkpoint case (resume is still a clean no-op)
- [x] `TestJSON_SprintResume_MultipleCheckpoints_AllCleared` — documents "resume clears ALL open rows" rule
- [x] Pre-existing `TestJSON_SprintPauseResume` still passes (no behavioural regression for the existing JSON shape)
- [x] Full `go test ./...` clean except for one pre-existing slow test (`TestBuildStoryContext_NutritionV2Go_Story12_HasCodeContext`) that also fails on `main`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>