### PR TITLE
fix(cli): repair sqlite-era regressions in list, add-concerns; add next-actions alias

### DIFF
--- a/application/state/concerns.go
+++ b/application/state/concerns.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AddConcernsInput is one element of the input JSON array. The schema is
+// intentionally open — bmad add-concerns historically accepted the v4
+// QAConcern {severity, note} shape, but the v6 store records arbitrary
+// JSON-shaped payloads per row (see domain/state.Concern.BodyJSON).
+//
+// Callers pass either:
+//
+//	[{"severity":"high","note":"missing test"}]
+//	[{"stage":"code-review","finding":"flaky table-driven test"}]
+//
+// or any other JSON-shaped object — each element is round-tripped through
+// json.Marshal and stored verbatim. The CLI's Long help surfaces the
+// full schema so operators don't have to grep the source.
+type AddConcernsInput = map[string]any
+
+// AddConcernsResult summarizes a successful add for the JSON envelope.
+type AddConcernsResult struct {
+	StoryID string `json:"story_id"`
+	Added   int    `json:"added"`
+	Source  string `json:"source"`
+}
+
+// AddConcerns appends one row per element of `entries` to the v6
+// story_concerns table. `source` is the provenance tag (e.g. "cli",
+// "code-review", "qa-gate") so downstream readers can group concerns
+// by where they came from.
+//
+// Returns an error if the story does not exist or if any element fails
+// to marshal back to JSON (which only happens for non-encodable types
+// like channels or func — practically impossible from a CLI string arg).
+func (s *StoryService) AddConcerns(
+	ctx context.Context,
+	storyID, source string,
+	entries []AddConcernsInput,
+) (AddConcernsResult, error) {
+	if _, err := s.Stories.Get(ctx, storyID); err != nil {
+		return AddConcernsResult{}, fmt.Errorf("add-concerns %q: %w", storyID, err)
+	}
+	for i, entry := range entries {
+		body, err := json.Marshal(entry)
+		if err != nil {
+			return AddConcernsResult{}, fmt.Errorf("add-concerns %q: marshal entry %d: %w", storyID, i, err)
+		}
+		if err := s.Concerns.Add(ctx, storyID, source, string(body)); err != nil {
+			return AddConcernsResult{}, fmt.Errorf("add-concerns %q: store entry %d: %w", storyID, i, err)
+		}
+	}
+	return AddConcernsResult{StoryID: storyID, Added: len(entries), Source: source}, nil
+}

--- a/application/state/list.go
+++ b/application/state/list.go
@@ -1,0 +1,98 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+)
+
+// ListFilter mirrors the v4 application.ListFilter shape against the v6
+// state store. Empty pointer fields are "any".
+//
+// UnblockedOnly resolves "blockers" via story_dependencies: a v6 story is
+// considered unblocked when every depends_on edge points at a story whose
+// status = complete.
+type ListFilter struct {
+	Status        *state.Status
+	ParallelGroup *int
+	UnblockedOnly bool
+}
+
+// ListBlocker is one dependency edge enriched with its resolution status,
+// suitable for the table-print path.
+type ListBlocker struct {
+	ID       string `json:"id"`
+	Resolved bool   `json:"resolved"`
+}
+
+// ListRow is one story plus its blocker resolution snapshot.
+type ListRow struct {
+	Story    state.Story   `json:"story"`
+	Blockers []ListBlocker `json:"blockers"`
+}
+
+// List streams the SQLite stories table through the filter set and returns
+// the enriched rows. Each row is decorated with its full dependency list +
+// resolution markers so callers can either print blockers (--show-blockers)
+// or filter by unblocked-only without a second round trip.
+//
+// The implementation is intentionally one query per story for the
+// blocker enrichment — the typical sprint has dozens to a few hundred
+// stories, and StoryDependencies.Of is a pinpoint SQL lookup. If profiling
+// shows this is a hot path on multi-thousand-story sprints, a bulk
+// "DependenciesForAll" port can be added without changing this signature.
+func (s *StoryService) List(ctx context.Context, f ListFilter) ([]ListRow, error) {
+	dbFilter := state.StoryFilter{}
+	if f.Status != nil {
+		dbFilter.Status = f.Status
+	}
+	if f.ParallelGroup != nil {
+		dbFilter.ParallelGroup = f.ParallelGroup
+	}
+
+	stories, err := s.Stories.List(ctx, dbFilter)
+	if err != nil {
+		return nil, fmt.Errorf("list stories: %w", err)
+	}
+
+	// statusByID caches lookups so a story with N deps doesn't issue N
+	// extra Stories.Get round trips when deps overlap across many rows
+	// (which is the common case in a sprint).
+	statusByID := make(map[string]state.Status, len(stories))
+	for _, st := range stories {
+		statusByID[st.ID] = st.Status
+	}
+
+	rows := make([]ListRow, 0, len(stories))
+	for _, st := range stories {
+		deps, err := s.Dependencies.Of(ctx, st.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list stories: deps for %s: %w", st.ID, err)
+		}
+		blockers := make([]ListBlocker, 0, len(deps))
+		allResolved := true
+		for _, depID := range deps {
+			status, ok := statusByID[depID]
+			if !ok {
+				// Dep points at a story not in the current listing — go
+				// look it up directly so the resolution check is correct.
+				dep, derr := s.Stories.Get(ctx, depID)
+				if derr == nil {
+					status = dep.Status
+					statusByID[depID] = status
+				}
+			}
+			resolved := status == state.StatusComplete
+			if !resolved {
+				allResolved = false
+			}
+			blockers = append(blockers, ListBlocker{ID: depID, Resolved: resolved})
+		}
+		if f.UnblockedOnly && !allResolved {
+			continue
+		}
+		rows = append(rows, ListRow{Story: st, Blockers: blockers})
+	}
+	return rows, nil
+}

--- a/application/state/list_test.go
+++ b/application/state/list_test.go
@@ -1,0 +1,199 @@
+package state_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	appstate "github.com/sosalejandro/bmad-story-runner-cli/application/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
+	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure/state/sqlite"
+)
+
+func newServiceForTest(t *testing.T) (*appstate.StoryService, func()) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "bmad-state.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	svc := &appstate.StoryService{
+		Stories:      sqlite.NewStoriesStore(db),
+		Dependencies: sqlite.NewStoryDependenciesStore(db),
+		Affects:      sqlite.NewStoryAffectsStore(db),
+		Concerns:     sqlite.NewStoryConcernsStore(db),
+		RetryCounts:  sqlite.NewStoryRetryCountsStore(db),
+		Config:       sqlite.NewConfigStore(db),
+		Checkpoints:  sqlite.NewCheckpointsStore(db),
+	}
+	return svc, func() { _ = db.Close() }
+}
+
+// TestList_NoFilter returns every story with empty blocker rows when no
+// dependencies exist.
+func TestList_NoFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, cleanup := newServiceForTest(t)
+	defer cleanup()
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(svc.Stories.Insert(ctx, state.Story{
+		ID: "1.1", Title: "alpha", Status: state.StatusPending,
+		Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode,
+	}))
+	must(svc.Stories.Insert(ctx, state.Story{
+		ID: "1.2", Title: "beta", Status: state.StatusComplete,
+		Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode,
+	}))
+
+	rows, err := svc.List(ctx, appstate.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if len(r.Blockers) != 0 {
+			t.Fatalf("story %s: blockers = %d, want 0", r.Story.ID, len(r.Blockers))
+		}
+	}
+}
+
+// TestList_StatusFilter narrows by status.
+func TestList_StatusFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, cleanup := newServiceForTest(t)
+	defer cleanup()
+
+	for _, s := range []state.Story{
+		{ID: "1.1", Status: state.StatusPending, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+		{ID: "1.2", Status: state.StatusComplete, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+		{ID: "1.3", Status: state.StatusPending, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+	} {
+		if err := svc.Stories.Insert(ctx, s); err != nil {
+			t.Fatalf("insert %s: %v", s.ID, err)
+		}
+	}
+
+	pending := state.StatusPending
+	rows, err := svc.List(ctx, appstate.ListFilter{Status: &pending})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("pending rows = %d, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.Story.Status != state.StatusPending {
+			t.Fatalf("got status %q, want pending", r.Story.Status)
+		}
+	}
+}
+
+// TestList_UnblockedOnly excludes stories whose deps aren't all complete and
+// marks each blocker with the correct resolution status.
+func TestList_UnblockedOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, cleanup := newServiceForTest(t)
+	defer cleanup()
+
+	for _, s := range []state.Story{
+		{ID: "1.1", Status: state.StatusComplete, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+		{ID: "1.2", Status: state.StatusPending, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+		{ID: "2.1", Status: state.StatusPending, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+		{ID: "2.2", Status: state.StatusPending, Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode},
+	} {
+		if err := svc.Stories.Insert(ctx, s); err != nil {
+			t.Fatalf("insert %s: %v", s.ID, err)
+		}
+	}
+	// 2.1 depends on 1.1 (resolved) → unblocked.
+	// 2.2 depends on 1.2 (pending) → blocked.
+	if err := svc.Dependencies.Add(ctx, "2.1", "1.1"); err != nil {
+		t.Fatalf("dep 2.1->1.1: %v", err)
+	}
+	if err := svc.Dependencies.Add(ctx, "2.2", "1.2"); err != nil {
+		t.Fatalf("dep 2.2->1.2: %v", err)
+	}
+
+	rows, err := svc.List(ctx, appstate.ListFilter{UnblockedOnly: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	gotIDs := map[string]bool{}
+	for _, r := range rows {
+		gotIDs[r.Story.ID] = true
+	}
+	if !gotIDs["1.1"] || !gotIDs["1.2"] || !gotIDs["2.1"] {
+		t.Fatalf("unblocked rows missing expected ids: got %v", gotIDs)
+	}
+	if gotIDs["2.2"] {
+		t.Fatalf("blocked story 2.2 should have been excluded by UnblockedOnly")
+	}
+}
+
+// TestAddConcerns_SQLite stores one row per array element.
+func TestAddConcerns_SQLite(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, cleanup := newServiceForTest(t)
+	defer cleanup()
+
+	if err := svc.Stories.Insert(ctx, state.Story{
+		ID: "1.1", Title: "alpha", Status: state.StatusPending,
+		Complexity: state.ComplexityLow, StoryType: state.StoryTypeCode,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	entries := []appstate.AddConcernsInput{
+		{"severity": "high", "note": "missing rollback test"},
+		{"stage": "code-review", "finding": "flaky goroutine"},
+	}
+	res, err := svc.AddConcerns(ctx, "1.1", "code-review", entries)
+	if err != nil {
+		t.Fatalf("AddConcerns: %v", err)
+	}
+	if res.Added != 2 || res.StoryID != "1.1" || res.Source != "code-review" {
+		t.Fatalf("result = %+v", res)
+	}
+
+	got, err := svc.Concerns.Of(ctx, "1.1")
+	if err != nil {
+		t.Fatalf("Concerns.Of: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("concerns rows = %d, want 2", len(got))
+	}
+	for _, c := range got {
+		if c.Source != "code-review" {
+			t.Fatalf("source = %q, want code-review", c.Source)
+		}
+		if c.BodyJSON == "" {
+			t.Fatalf("body_json empty")
+		}
+	}
+}
+
+// TestAddConcerns_StoryNotFound surfaces the domain not-found error so the
+// CLI can route it through cobra's normal error path (non-zero exit).
+func TestAddConcerns_StoryNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, cleanup := newServiceForTest(t)
+	defer cleanup()
+
+	_, err := svc.AddConcerns(ctx, "9.9", "cli", []appstate.AddConcernsInput{{"note": "x"}})
+	if err == nil {
+		t.Fatal("expected error for missing story, got nil")
+	}
+}

--- a/cmd/add_concerns.go
+++ b/cmd/add_concerns.go
@@ -1,32 +1,124 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sosalejandro/bmad-story-runner-cli/application"
+	appstate "github.com/sosalejandro/bmad-story-runner-cli/application/state"
 	"github.com/sosalejandro/bmad-story-runner-cli/domain"
 	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure"
 )
 
+// addConcernsLongHelp documents the JSON schema for add-concerns input.
+// Surfaced in the cobra Long field so operators don't have to grep the
+// source for what fields QAConcern accepts (issue #71 sub-issue 3).
+const addConcernsLongHelp = `Append QA concerns to a story.
+
+Backend auto-detection (issue #71):
+  - 2 positional args (<story-id> <concerns-json>)            → v6 SQLite store
+  - 3 positional args with the first ending in .db / no ext  → v6 SQLite store,
+    with the first arg overriding --state
+  - 3 positional args with the first ending in .json         → legacy v4
+    bmad-progress.json (back-compat)
+
+JSON schema (v6 SQLite — each array element is stored as one
+story_concerns row with body_json = the element serialized):
+
+  Open-shaped object. Common fields:
+
+    severity  string  (one of: low, medium, high, critical) — optional
+    note      string  free-form description — optional
+    stage     string  pipeline stage that surfaced the concern (e.g.
+                      "code-review", "qa-gate") — optional
+    finding   string  short summary suitable for a list table — optional
+
+  Any additional keys are preserved verbatim in body_json. The --source
+  flag tags the entire batch (defaults to "cli").
+
+JSON schema (v4 legacy JSON store — strict):
+
+  [{"severity":"<low|medium|high|critical>", "note":"<text>"}]
+
+Examples:
+  bmad add-concerns 1.1 '[{"severity":"high","note":"missing rollback test"}]'
+  bmad add-concerns 1.1 '[{"stage":"code-review","finding":"flaky goroutine"}]' \
+      --source code-review
+  bmad add-concerns ./other-sprint.db 1.1 '[{"severity":"low","note":"nit"}]'`
+
 func newAddConcernsCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   `add-concerns <progress-json> <story-id> <concerns-json>`,
-		Short: "Append QA concerns to a story",
-		Long:  `concerns-json must be a JSON array, e.g. '[{"severity":"high","note":"missing test"}]'`,
-		Args:  cobra.ExactArgs(3),
-		Run: func(cmd *cobra.Command, args []string) {
-			var concerns []domain.QAConcern
-			if err := json.Unmarshal([]byte(args[2]), &concerns); err != nil {
-				exitOnError(fmt.Errorf("parsing concerns JSON: %w", err))
+	var source string
+
+	cmd := &cobra.Command{
+		Use:   `add-concerns [<progress-json>] <story-id> <concerns-json>`,
+		Short: "Append QA concerns to a story (auto-detects SQLite vs legacy JSON)",
+		Long:  addConcernsLongHelp,
+		Args:  cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Two args: SQLite mode, args are <story-id> <concerns-json>.
+			// Three args: arg[0] is the path; detect backend from it.
+			var storyID, concernsJSON string
+			backend := backendSQLite
+			if len(args) == 2 {
+				storyID, concernsJSON = args[0], args[1]
+			} else {
+				detected, _ := resolveStateBackend(args[0])
+				backend = detected
+				storyID, concernsJSON = args[1], args[2]
 			}
 
-			store := infrastructure.NewJSONProgressStore(log)
-			uc := application.NewAddConcernsUseCase(store, log)
-			exitOnError(uc.Execute(args[0], args[1], concerns))
-			fmt.Printf("Added %d concern(s) to %s\n", len(concerns), args[1])
+			if backend == backendSQLite {
+				return runAddConcernsSQLite(storyID, concernsJSON, source)
+			}
+			return runAddConcernsJSON(args[0], storyID, concernsJSON)
 		},
 	}
+
+	cmd.Flags().StringVar(&source, "source", "cli",
+		"provenance tag stored in story_concerns.source (SQLite mode only)")
+	addV6PersistentFlags(cmd)
+
+	return cmd
+}
+
+// runAddConcernsSQLite writes each element of the input array as a separate
+// story_concerns row, tagged with --source (default "cli").
+func runAddConcernsSQLite(storyID, concernsJSON, source string) error {
+	var entries []appstate.AddConcernsInput
+	if err := json.Unmarshal([]byte(concernsJSON), &entries); err != nil {
+		return fmt.Errorf("parsing concerns JSON: %w", err)
+	}
+
+	ctx := context.Background()
+	svc, cleanup, err := openStoryService(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	res, err := svc.AddConcerns(ctx, storyID, source, entries)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Added %d concern(s) to %s (source=%s)\n", res.Added, res.StoryID, res.Source)
+	return nil
+}
+
+// runAddConcernsJSON is the legacy v4 path — preserved for back-compat
+// with pre-SQLite-migration workflows.
+func runAddConcernsJSON(progressPath, storyID, concernsJSON string) error {
+	var concerns []domain.QAConcern
+	if err := json.Unmarshal([]byte(concernsJSON), &concerns); err != nil {
+		return fmt.Errorf("parsing concerns JSON: %w", err)
+	}
+	store := infrastructure.NewJSONProgressStore(log)
+	uc := application.NewAddConcernsUseCase(store, log)
+	if err := uc.Execute(progressPath, storyID, concerns); err != nil {
+		return err
+	}
+	fmt.Printf("Added %d concern(s) to %s\n", len(concerns), storyID)
+	return nil
 }

--- a/cmd/backend_detect.go
+++ b/cmd/backend_detect.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+)
+
+// stateBackend is the resolved backend kind for cmds that historically took a
+// positional progress-file path AND now must also accept the v6 SQLite store.
+type stateBackend int
+
+const (
+	// backendSQLite means the v6 sqlite store is in play. The cmd should
+	// open it via openV6DB (which honors --state / BMAD_STATE / cwd).
+	backendSQLite stateBackend = iota
+	// backendLegacyJSON means the operator handed us a v4 bmad-progress.json
+	// path explicitly — fall through to the legacy NewJSONProgressStore code
+	// path so back-compat workflows still run.
+	backendLegacyJSON
+)
+
+// resolveStateBackend picks the backend for `bmad list` / `bmad add-concerns`
+// (issue #71). Rule:
+//
+//  1. If no positional arg is supplied, use SQLite (the modern default).
+//  2. If the arg ends in `.db` (case-insensitive), use SQLite and route the
+//     path through --state by overwriting v6StatePathFlag — that way every
+//     downstream call to resolveStatePath / openV6DB sees the operator
+//     intent.
+//  3. Otherwise treat the arg as a legacy JSON path (v4 back-compat).
+//
+// The returned `consumedArg` is true when the function captured the
+// positional arg for its own purposes (case 2); the caller should NOT
+// then forward it to the legacy JSON-store code.
+func resolveStateBackend(arg string) (backend stateBackend, consumedArg bool) {
+	if arg == "" {
+		return backendSQLite, false
+	}
+	lower := strings.ToLower(arg)
+	if strings.HasSuffix(lower, ".db") {
+		// Operator handed us an explicit .db path — route it through the
+		// --state flag so openV6DB picks it up. We deliberately overwrite
+		// even if --state was already set; CLI positional args win
+		// over implicit defaults but lose to nothing (matches the
+		// precedence operators expect from other Unix tools).
+		v6StatePathFlag = absPath(arg)
+		return backendSQLite, true
+	}
+	if strings.HasSuffix(lower, ".json") {
+		return backendLegacyJSON, false
+	}
+	// Unknown suffix: if the file exists and starts with the SQLite magic
+	// bytes ("SQLite format 3"), trust that. Otherwise fall back to legacy
+	// JSON (preserves pre-#71 behaviour for anyone calling with a path that
+	// happens to lack an extension).
+	if isSQLiteFile(arg) {
+		v6StatePathFlag = absPath(arg)
+		return backendSQLite, true
+	}
+	return backendLegacyJSON, false
+}
+
+// isSQLiteFile peeks the first 16 bytes for the standard SQLite header.
+// Returns false on any read error — callers fall back to legacy JSON.
+func isSQLiteFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	header := make([]byte, 16)
+	n, err := f.Read(header)
+	if err != nil || n < 16 {
+		return false
+	}
+	return string(header) == "SQLite format 3\x00"
+}

--- a/cmd/backend_detect_test.go
+++ b/cmd/backend_detect_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveStateBackend covers the SQLite-vs-legacy-JSON detection
+// for `bmad list` / `bmad add-concerns` (issue #71).
+func TestResolveStateBackend(t *testing.T) {
+	t.Run("empty arg → SQLite", func(t *testing.T) {
+		v6StatePathFlag = ""
+		b, consumed := resolveStateBackend("")
+		if b != backendSQLite || consumed {
+			t.Fatalf("got (%v, %v), want (SQLite, false)", b, consumed)
+		}
+	})
+
+	t.Run(".db suffix → SQLite, consumes arg", func(t *testing.T) {
+		v6StatePathFlag = ""
+		b, consumed := resolveStateBackend("./bmad-state.db")
+		if b != backendSQLite || !consumed {
+			t.Fatalf("got (%v, %v), want (SQLite, true)", b, consumed)
+		}
+		if v6StatePathFlag == "" || !strings.HasSuffix(v6StatePathFlag, "bmad-state.db") {
+			t.Fatalf("v6StatePathFlag not set to absolute .db path: %q", v6StatePathFlag)
+		}
+	})
+
+	t.Run(".json suffix → legacy JSON, does not consume arg", func(t *testing.T) {
+		v6StatePathFlag = ""
+		b, consumed := resolveStateBackend("./bmad-progress.json")
+		if b != backendLegacyJSON || consumed {
+			t.Fatalf("got (%v, %v), want (JSON, false)", b, consumed)
+		}
+		if v6StatePathFlag != "" {
+			t.Fatalf("v6StatePathFlag should not be set, got %q", v6StatePathFlag)
+		}
+	})
+
+	t.Run("no extension + SQLite magic bytes → SQLite", func(t *testing.T) {
+		v6StatePathFlag = ""
+		dir := t.TempDir()
+		path := filepath.Join(dir, "no-ext-state")
+		// SQLite header is "SQLite format 3\x00" — write it + some padding.
+		if err := os.WriteFile(path, append([]byte("SQLite format 3\x00"), make([]byte, 100)...), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		b, consumed := resolveStateBackend(path)
+		if b != backendSQLite || !consumed {
+			t.Fatalf("got (%v, %v), want (SQLite, true)", b, consumed)
+		}
+	})
+
+	t.Run("no extension + non-SQLite header → legacy JSON", func(t *testing.T) {
+		v6StatePathFlag = ""
+		dir := t.TempDir()
+		path := filepath.Join(dir, "old-progress")
+		if err := os.WriteFile(path, []byte(`{"stories":[]}`), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		b, consumed := resolveStateBackend(path)
+		if b != backendLegacyJSON || consumed {
+			t.Fatalf("got (%v, %v), want (JSON, false)", b, consumed)
+		}
+	})
+}
+
+// TestIsSQLiteFile covers the magic-byte sniff used by resolveStateBackend
+// when the operator hands us a path with no obvious extension.
+func TestIsSQLiteFile(t *testing.T) {
+	t.Run("missing file → false", func(t *testing.T) {
+		if isSQLiteFile(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Fatal("expected false for missing file")
+		}
+	})
+
+	t.Run("too short → false", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tiny")
+		if err := os.WriteFile(path, []byte("hi"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if isSQLiteFile(path) {
+			t.Fatal("expected false for too-short file")
+		}
+	})
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sosalejandro/bmad-story-runner-cli/application"
+	appstate "github.com/sosalejandro/bmad-story-runner-cli/application/state"
 	"github.com/sosalejandro/bmad-story-runner-cli/domain"
+	"github.com/sosalejandro/bmad-story-runner-cli/domain/state"
 	"github.com/sosalejandro/bmad-story-runner-cli/infrastructure"
 )
 
@@ -21,45 +24,33 @@ func newListCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "list <progress-json>",
+		Use:   "list [<progress-json>]",
 		Short: "List stories with filtering by group, status, and blocker resolution",
-		Long: `List stories from the progress file with flexible filtering.
+		Long: `List stories with flexible filtering.
+
+Backend auto-detection (issue #71):
+  - no positional arg, or arg ending in .db → v6 SQLite store
+    (path resolved via --state, $BMAD_STATE, or ./bmad-state.db)
+  - arg ending in .json → legacy v4 bmad-progress.json
+  - other: peek the file header for the SQLite magic bytes; fall back
+    to the v4 JSON store if not a SQLite database
 
 Examples:
-  bmad list progress.json --group 3 --filter-group
-  bmad list progress.json --status pending --show-blockers
-  bmad list progress.json --group 3 --filter-group --unblocked-only`,
-		Args: cobra.ExactArgs(1),
+  bmad list --status pending --unblocked-only      # SQLite (default)
+  bmad list ./other-sprint.db --status pending     # SQLite (explicit)
+  bmad list bmad-progress.json --group 3 --filter-group  # legacy JSON`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store := infrastructure.NewJSONProgressStore(log)
-			uc := application.NewListStoriesUseCase(store, log)
+			posArg := ""
+			if len(args) == 1 {
+				posArg = args[0]
+			}
+			backend, _ := resolveStateBackend(posArg)
 
-			filter := application.ListFilter{
-				UnblockedOnly: unblockedOnly,
+			if backend == backendSQLite {
+				return runListSQLite(cmd, status, group, filterGroup, unblockedOnly, showBlockers)
 			}
-			if filterGroup {
-				filter.Group = &group
-			}
-			if status != "" {
-				st, err := domain.ParseStatus(status)
-				if err != nil {
-					return err
-				}
-				filter.Status = &st
-			}
-
-			rows, err := uc.Execute(args[0], filter)
-			if err != nil {
-				return err
-			}
-
-			if len(rows) == 0 {
-				fmt.Println("No stories match the given filters.")
-				return nil
-			}
-
-			printListTable(rows, showBlockers)
-			return nil
+			return runListJSON(posArg, status, group, filterGroup, unblockedOnly, showBlockers)
 		},
 	}
 
@@ -68,8 +59,120 @@ Examples:
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status (pending, in-progress, qa-review, complete, blocked)")
 	cmd.Flags().BoolVar(&showBlockers, "show-blockers", false, "Show blocker IDs with resolution status")
 	cmd.Flags().BoolVar(&unblockedOnly, "unblocked-only", false, "Only show stories whose blockers are all resolved")
+	// --state shares the persistent flag block with the rest of v6 cmds so
+	// `bmad list --state /tmp/sprint.db` works without a positional arg.
+	addV6PersistentFlags(cmd)
 
 	return cmd
+}
+
+// runListSQLite is the v6 path — opens the resolved bmad-state.db and runs
+// the application.state.StoryService.List use case.
+func runListSQLite(cmd *cobra.Command, status string, group int, filterGroup, unblockedOnly, showBlockers bool) error {
+	ctx := context.Background()
+	svc, cleanup, err := openStoryService(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	filter := appstate.ListFilter{UnblockedOnly: unblockedOnly}
+	if filterGroup {
+		g := group
+		filter.ParallelGroup = &g
+	}
+	if status != "" {
+		st := state.Status(status)
+		filter.Status = &st
+	}
+
+	rows, err := svc.List(ctx, filter)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		fmt.Println("No stories match the given filters.")
+		return nil
+	}
+	printListTableV6(rows, showBlockers)
+	return nil
+}
+
+// runListJSON is the legacy v4 path — preserved for back-compat with
+// pre-SQLite-migration workflows that still drive a bmad-progress.json.
+func runListJSON(path, status string, group int, filterGroup, unblockedOnly, showBlockers bool) error {
+	store := infrastructure.NewJSONProgressStore(log)
+	uc := application.NewListStoriesUseCase(store, log)
+
+	filter := application.ListFilter{UnblockedOnly: unblockedOnly}
+	if filterGroup {
+		g := group
+		filter.Group = &g
+	}
+	if status != "" {
+		st, err := domain.ParseStatus(status)
+		if err != nil {
+			return err
+		}
+		filter.Status = &st
+	}
+
+	rows, err := uc.Execute(path, filter)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		fmt.Println("No stories match the given filters.")
+		return nil
+	}
+	printListTable(rows, showBlockers)
+	return nil
+}
+
+func printListTableV6(rows []appstate.ListRow, showBlockers bool) {
+	maxStatus := len("STATUS")
+	maxID := len("STORY ID")
+	for _, r := range rows {
+		if l := len(string(r.Story.Status)); l > maxStatus {
+			maxStatus = l
+		}
+		if l := len(r.Story.ID); l > maxID {
+			maxID = l
+		}
+	}
+
+	if showBlockers {
+		fmt.Printf("%-*s | %-*s | BLOCKERS\n", maxStatus, "STATUS", maxID, "STORY ID")
+		fmt.Printf("%s-|-%s-|-%s\n", repeat("-", maxStatus), repeat("-", maxID), repeat("-", 30))
+	} else {
+		fmt.Printf("%-*s | %-*s | TITLE\n", maxStatus, "STATUS", maxID, "STORY ID")
+		fmt.Printf("%s-|-%s-|-%s\n", repeat("-", maxStatus), repeat("-", maxID), repeat("-", 30))
+	}
+
+	for _, r := range rows {
+		if showBlockers {
+			fmt.Printf("%-*s | %-*s | %s\n", maxStatus, string(r.Story.Status), maxID, r.Story.ID, formatBlockersV6(r.Blockers))
+		} else {
+			fmt.Printf("%-*s | %-*s | %s\n", maxStatus, string(r.Story.Status), maxID, r.Story.ID, r.Story.Title)
+		}
+	}
+
+	fmt.Printf("\n%d stories listed.\n", len(rows))
+}
+
+func formatBlockersV6(blockers []appstate.ListBlocker) string {
+	if len(blockers) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(blockers))
+	for _, b := range blockers {
+		marker := "✗"
+		if b.Resolved {
+			marker = "✓"
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", b.ID, marker))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func printListTable(rows []application.ListRow, showBlockers bool) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,26 +54,27 @@ so Claude does not need to write inline Python or bash scripts.`,
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Emit output as a JSON envelope (schema v1)")
 
 	root.AddCommand(
-		newInitCmd(),       // v6 — sqlite init
-		newInstallCmd(),    // v6 — drop embedded agents + skills into .claude/
-		newConfigCmd(),     // v6 — runtime config get/set
-		newStoryCmd(),      // v6 — story namespace
-		newEnvCmd(),        // v6 — env namespace (port-pool + sweeper)
-		newWorktreeCmd(),   // v6 — worktree namespace
-		newDepguardCmd(),   // v6 — depguard flip ratchet
-		newGateCmd(),       // v6 — gate namespace (v4 surface preserved)
-		newDispatchCmd(),   // v6 — dispatch record (§12.7 token cost)
-		newRenderCmd(),     // v6 — prompt template render
+		newInitCmd(),        // v6 — sqlite init
+		newInstallCmd(),     // v6 — drop embedded agents + skills into .claude/
+		newConfigCmd(),      // v6 — runtime config get/set
+		newStoryCmd(),       // v6 — story namespace
+		newEnvCmd(),         // v6 — env namespace (port-pool + sweeper)
+		newWorktreeCmd(),    // v6 — worktree namespace
+		newDepguardCmd(),    // v6 — depguard flip ratchet
+		newGateCmd(),        // v6 — gate namespace (v4 surface preserved)
+		newDispatchCmd(),    // v6 — dispatch record (§12.7 token cost)
+		newRenderCmd(),      // v6 — prompt template render
 		newSystemCheckCmd(), // v6 — host resource probe
 		newDoctorCmd(),      // v6 — env self-check (binary/atlas/db/schema/exit codes)
 		newSprintCmd(),      // v6 — sprint namespace (plan/run/pause/resume/status)
-		newMigrateCmd(),    // v6 — one-shot v4 progress.json → v6 sqlite import
+		newMigrateCmd(),     // v6 — one-shot v4 progress.json → v6 sqlite import
 		newStatusCmd(),
 		newSetStatusCmd(),
 		newSetCompleteCmd(),
 		newBulkCompleteCmd(),
 		newAddConcernsCmd(),
 		newNextCmd(),
+		newNextActionsAliasCmd(), // v6 — top-level alias for `bmad story next` (issue #71)
 		newMarkStoryFileCmd(),
 		newScanCmd(),
 		newAssignGroupsCmd(),

--- a/cmd/story.go
+++ b/cmd/story.go
@@ -251,7 +251,30 @@ agent returns produces the same instruction.`,
 
 // ---------- next ----------
 
+// newStoryNextCmd is the canonical `bmad story next` command. The same
+// command body is also exposed at the root as `bmad next-actions` via
+// newNextActionsAliasCmd — both call buildNextCmd with their own Use
+// string so flag-bound state isn't shared across the two registrations.
 func newStoryNextCmd() *cobra.Command {
+	return buildNextCmd("next")
+}
+
+// newNextActionsAliasCmd is the top-level `bmad next-actions` alias
+// (issue #71 sub-issue 1). The orchestrator skill documents this verb
+// throughout its sprint loop spec; the real command lives at
+// `bmad story next`. This alias preserves the entire flag surface
+// (--max-parallel, --claim, --claimer, --scope, --no-hydration-priority)
+// so skill docs referencing `bmad next-actions` resolve at runtime.
+func newNextActionsAliasCmd() *cobra.Command {
+	cmd := buildNextCmd("next-actions")
+	cmd.Short = "Alias of `bmad story next` — emit a parallel-eligible next-action batch"
+	// Persistent --state flag normally lives on the story parent; surface
+	// it here too so `bmad next-actions --state ./bmad-state.db` works.
+	addV6PersistentFlags(cmd)
+	return cmd
+}
+
+func buildNextCmd(use string) *cobra.Command {
 	var (
 		max                 int
 		claim               bool
@@ -260,7 +283,7 @@ func newStoryNextCmd() *cobra.Command {
 		noHydrationPriority bool
 	)
 	cmd := &cobra.Command{
-		Use:   "next",
+		Use:   use,
 		Short: "Emit a parallel-eligible next-action batch",
 		Long: `By default emits candidates WITHOUT mutating state (--claim=false).
 With --claim, atomically marks the picked stories claimed_at + claimed_by


### PR DESCRIPTION
## Summary

Closes sub-issues 1, 2, 3 of #71. Sub-issues 4 + 5 are owned by parallel agents and untouched here.

Three CLI surface regressions from the v6 SQLite cutover, sharing the same root cause — cmd handlers still hard-coded the legacy v4 JSON store path resolution — plus one missing alias the embedded orchestrator skill documents but never existed.

- **`bmad next-actions`** is added as a top-level alias for `bmad story next`. The orchestrator SKILL.md references this verb throughout its sprint loop spec; the alias makes those docs resolve at runtime. Full flag surface preserved (`--max-parallel`, `--claim`, `--claimer`, `--scope`, `--no-hydration-priority`, `--state`).

- **`bmad list`** auto-detects the state backend. No positional arg or `.db` arg → v6 SQLite (path via `--state` / `BMAD_STATE` / `./bmad-state.db`). `.json` arg → legacy v4 JSON store (back-compat). Unknown extension → peek the SQLite magic-byte header.

- **`bmad add-concerns`** uses the same auto-detect. New clean 2-arg SQLite form (`<story-id> <concerns-json>`) lives alongside the historical 3-arg JSON form. Each input array element is stored as one `story_concerns` row with `body_json = element`; `--source` flag (default `"cli"`) tags the batch.

- **JSON schema** for `add-concerns` is now documented in the cobra Long help so operators don't have to grep `domain.QAConcern` to know what fields are accepted. Both v6 open-shaped and v4 strict schemas are shown with worked examples.

## Verification (against v0.5.0 binary, repro from issue body)

Build + init a test env, plan a tiny epics.md:

```
$ /tmp/bmadbin next-actions --help            # was: unknown command
By default emits candidates WITHOUT mutating state (--claim=false). ...
      --max-parallel int        override max parallel slots
      --claim                   atomically claim returned stories ...
      --claimer string          claimed_by value
      --scope string            restrict candidates to one epic id
      --no-hydration-priority   opt out of issue-#49 sort
      --state string            path to bmad-state.db

$ /tmp/bmadbin list --status pending --unblocked-only     # was: unmarshalling 'S'
STATUS  | STORY ID | TITLE
--------|----------|------
pending | 1.1      | alpha
pending | 1.3      | gamma
2 stories listed.

$ /tmp/bmadbin add-concerns 1.1 '[{"stage":"code-review","finding":"test"}]'  # was: accepts 3 args
Added 1 concern(s) to 1.1 (source=cli)
```

## Test plan

- [x] `go test ./...` (full repo, no regressions)
- [x] New `application/state/list_test.go` covers list filter branches + unblocked-only dep resolution + add-concerns happy path + story-not-found
- [x] New `cmd/backend_detect_test.go` covers every branch of `resolveStateBackend` (empty arg / `.db` / `.json` / magic-byte sniff / short-file edge case)
- [x] Smoke-tested all 3 verification flows from issue #71 end-to-end against a fresh `bmad init`

## Constraints honored

- `fix(cli):` conventional commit, lowercase subject
- One PR for all 3 sub-issues per shared root cause directive
- Did NOT touch sub-issue 4 (checkpoint clearing) or sub-issue 5 (context-bundle) per parallel-agent ownership
- Did NOT modify embedded orchestrator SKILL.md `next-actions` references — alias resolves them at runtime (Option A)
- Legacy JSON-store path preserved unchanged for back-compat

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>